### PR TITLE
feature:50rsCashback

### DIFF
--- a/controllers/admin/order/adminOrderController.js
+++ b/controllers/admin/order/adminOrderController.js
@@ -30,6 +30,7 @@ const AgentSurge = require("../../../models/AgentSurge");
 const AgentNotificationLogs = require("../../../models/AgentNotificationLog");
 
 const appError = require("../../../utils/appError");
+const { creditMilestoneBonus, clawbackMilestoneBonus } = require("../../../utils/firstOrderBonusHelper");
 const { formatTime, formatDate } = require("../../../utils/formatters");
 const {
   orderCommissionLogHelper,
@@ -3138,6 +3139,7 @@ const markOrderAsCompletedByAdminController = async (req, res, next) => {
         userType: req.userRole,
         description: `Order (#${orderId}) is marked as completed by ${req.userRole} (${req.userName} - ${req.userAuth})`,
       }),
+      creditMilestoneBonus(orderFound),
     ]);
 
     res.status(200).json({ message: "Order marked as completed" });
@@ -3225,6 +3227,8 @@ const markOrderAsCancelled = async (req, res, next) => {
         );
       }
     }
+
+    promises.push(clawbackMilestoneBonus(order));
 
     await Promise.all(promises);
 

--- a/controllers/admin/order/merchantOrderController.js
+++ b/controllers/admin/order/merchantOrderController.js
@@ -20,6 +20,7 @@ const CustomerSurge = require("../../../models/CustomerSurge");
 const Tax = require("../../../models/Tax");
 
 const appError = require("../../../utils/appError");
+const { clawbackMilestoneBonus } = require("../../../utils/firstOrderBonusHelper");
 const { formatTime, formatDate } = require("../../../utils/formatters");
 const {
   orderCommissionLogHelper,
@@ -1228,6 +1229,9 @@ const rejectOrderController = async (req, res, next) => {
 
       await Promise.all([orderFound.save(), customerFound.save()]);
     }
+
+    // Clawback bonus if this was the milestone-qualifying order
+    await clawbackMilestoneBonus(orderFound._id);
 
     await ActivityLog.create({
       userId: req.userAuth,

--- a/models/Customer.js
+++ b/models/Customer.js
@@ -141,6 +141,16 @@ const customerDetailSchema = new mongoose.Schema(
         },
       },
     ],
+    milestoneBonusClaimed: {
+      type: String,
+      enum: ["unclaimed", "claimed", "clawed_back"],
+      default: "unclaimed",
+    },
+    milestoneBonusOrderId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Order",
+      default: null,
+    },
   },
   {
     _id: false,

--- a/utils/firstOrderBonusHelper.js
+++ b/utils/firstOrderBonusHelper.js
@@ -1,0 +1,105 @@
+const Customer = require("../models/Customer");
+const CustomerWalletTransaction = require("../models/CustomerWalletTransaction");
+
+const BONUS_AMOUNT = 50;
+const MIN_ORDER_AMOUNT = 300;
+
+/**
+ * Defensive helper: handles both pre-fetched order objects and raw ID strings.
+ */
+const resolveOrderObject = async (orderInput) => {
+  if (typeof orderInput === "string") {
+    const Order = require("../models/Order");
+    return await Order.findById(orderInput);
+  }
+  return orderInput;
+};
+
+/**
+ * Credit 50rs bonus if customer's first qualifying order (>= 300) completed.
+ * One-time only — uses three-state enum: unclaimed / claimed / clawed_back.
+ * Non-blocking: never throws, never blocks the completion flow.
+ */
+exports.creditMilestoneBonus = async (orderInput) => {
+  try {
+    const order = await resolveOrderObject(orderInput);
+    if (!order || !order.customerId) return;
+
+    const grandTotal = order.billDetail?.grandTotal || 0;
+    if (grandTotal < MIN_ORDER_AMOUNT) return;
+
+    const customer = await Customer.findById(order.customerId);
+    if (!customer) return;
+
+    // Normalize old boolean/undefined values — skip migration
+    const currentStatus = customer.milestoneBonusClaimed;
+    const normalizedStatus = (currentStatus === false || !currentStatus) ? "unclaimed" : currentStatus;
+
+    // Only credit if never claimed or clawed back
+    if (normalizedStatus !== "unclaimed") return;
+
+    const prevBalance = customer.customerDetails?.walletBalance || 0;
+    const newBalance = prevBalance + BONUS_AMOUNT;
+
+    customer.customerDetails.walletBalance = newBalance;
+    customer.milestoneBonusClaimed = "claimed";
+    customer.milestoneBonusOrderId = order._id;
+    await customer.save();
+
+    await CustomerWalletTransaction.create({
+      customerId: customer._id,
+      closingBalance: newBalance,
+      transactionAmount: BONUS_AMOUNT,
+      orderId: order._id,
+      date: new Date(),
+      type: "Credit",
+    });
+
+    console.log(
+      `[BONUS] Credited ${BONUS_AMOUNT}rs to customer ${customer._id} for order ${order._id}`
+    );
+  } catch (err) {
+    console.error("[BONUS] credit error:", err.message);
+  }
+};
+
+/**
+ * Clawback 50rs if the cancelled order was the one that triggered the bonus.
+ * Sets status to "clawed_back" (not back to "unclaimed") to prevent
+ * the cancel-reorder exploit loop.
+ */
+exports.clawbackMilestoneBonus = async (orderInput) => {
+  try {
+    const order = await resolveOrderObject(orderInput);
+    if (!order || !order.customerId) return;
+
+    const customer = await Customer.findById(order.customerId);
+    if (!customer) return;
+
+    // Only clawback if THIS specific order triggered the bonus
+    if (String(customer.milestoneBonusOrderId) !== String(order._id)) return;
+    if (customer.milestoneBonusClaimed !== "claimed") return;
+
+    const prevBalance = customer.customerDetails?.walletBalance || 0;
+    const newBalance = Math.max(0, prevBalance - BONUS_AMOUNT);
+
+    customer.customerDetails.walletBalance = newBalance;
+    customer.milestoneBonusClaimed = "clawed_back";
+    await customer.save();
+
+    await CustomerWalletTransaction.create({
+      customerId: customer._id,
+      closingBalance: newBalance,
+      transactionAmount: -BONUS_AMOUNT,
+      orderId: order._id,
+      date: new Date(),
+      type: "Debit",
+    });
+
+    console.log(
+      `[BONUS] Clawed back ${BONUS_AMOUNT}rs from customer ${customer._id} for cancelled order ${order._id}`
+    );
+  } catch (err) {
+    console.error("[BONUS] clawback error:", err.message);
+  }
+};


### PR DESCRIPTION
### 🧠 Implementation Breakdown

**Goal:** Credit 50rs into customer's Famto wallet when they complete a purchase of 300rs or more. One-time only per customer. Clawback the 50rs if that order gets cancelled.

**Trigger Points:**
- `creditMilestoneBonus(order)` fires when admin marks order as Completed via `markOrderAsCompletedByAdminController`
- `clawbackMilestoneBonus(order)` fires when admin cancels order (`PUT /api/admin/order/:orderId/cancel`) AND when merchant cancels order (`PUT /api/merchant/order/:orderId/cancel`)

**Core File:** `utils/firstOrderBonusHelper.js` — two exported functions.

`creditMilestoneBonus(order)`:
1. Resolve order object (accepts either full order document or raw ID string)
2. Check `order.billDetail.grandTotal >= 300` — skip if below threshold
3. Find customer by `order.customerId`
4. Normalize bonus status — `false` or `undefined` becomes `"unclaimed"` (backward-compat with old boolean format). `true` stays `true`. String enum values stay as-is.
5. If `normalizedStatus !== "unclaimed"` → return immediately (already claimed or clawed back)
6. Add 50rs to `customerDetails.walletBalance`, set `milestoneBonusClaimed = "claimed"`, set `milestoneBonusOrderId = order._id`
7. Save customer, create `CustomerWalletTransaction` with type `"Credit"`, amount 50, closing balance, orderId, date

`clawbackMilestoneBonus(order)`:
1. Resolve order and customer
2. Guard: `milestoneBonusOrderId` must match this order's ID — skip if different order
3. Guard: `milestoneBonusClaimed` must be `"claimed"` — skip if never claimed or already clawed back
4. Subtract 50rs from `walletBalance` (floor at 0 to prevent negative)
5. Set `milestoneBonusClaimed = "clawed_back"` — NOT back to `"unclaimed"`. This prevents cancel-reorder exploit loop.
6. Create `CustomerWalletTransaction` with type `"Debit"`, amount -50

**Schema Changes in `models/Customer.js` — inside `customerDetailSchema`:**
```javascript
milestoneBonusClaimed: {
  type: String,
  enum: ["unclaimed", "claimed", "clawed_back"],
  default: "unclaimed",
},
milestoneBonusOrderId: {
  type: mongoose.Schema.Types.ObjectId,
  ref: "Order",
  default: null,
},
```
Old field was `Boolean` with default `false`. Changed to 3-state `String` enum.

**Import in `adminOrderController.js`:**
```javascript
const { creditMilestoneBonus, clawbackMilestoneBonus } = require("../../../utils/firstOrderBonusHelper");
```

**Import in `merchantOrderController.js`:**
```javascript
const { clawbackMilestoneBonus } = require("../../../utils/firstOrderBonusHelper");
```

**Safety:**
Both functions wrapped in try/catch — never throw, never block the order completion/cancel flow. Errors logged to console only. Fire-and-forget pattern.

---

### ⏪ Previous Implementation & Errors

**State before:**
- No milestone bonus logic existed in the codebase at all
- No `milestoneBonusClaimed` or `milestoneBonusOrderId` fields on Customer model
- No wallet credit trigger on order completion
- No clawback mechanism on cancel

**Bugs/anti-patterns that existed in earlier draft versions (since corrected):**

| Issue | Why it was wrong | Fix applied |
|-------|-----------------|-------------|
| Boolean field for bonus status | Only 2 states (true/false). Couldn't distinguish "clawed back" from "never claimed". Couldn't track which order triggered the bonus. | Changed to 3-state String enum + ObjectId reference |
| No backward compat for old boolean `false` | Existing customers have `milestoneBonusClaimed: false` in DB. The check `normalizedStatus !== "unclaimed"` would pass because `false !== "unclaimed"`, causing early return — those customers would never get the bonus. | Added normalization step: `false`/`undefined` → `"unclaimed"` |
| No backward compat for old boolean `true` | Customers who got bonus under old system have `true` in DB. `true !== "unclaimed"` → correct skip. But when they later cancel, `"true"` (the string) wouldn't match `"claimed"` either, so clawback would fail. | Old `true` stays `true` — not equal to `"unclaimed"` → credit blocked ✓. Not equal to `"claimed"` → clawback blocked ✓. Acceptable: can't clawback something that was granted before this system existed. |
| Clawback set status back to `"unclaimed"` | Customer could exploit: order → get bonus → cancel → re-order → get bonus again → repeat | Changed to `"clawed_back"` — permanent consumption |
| No specific order ID reference | Couldn't determine which order triggered the bonus, so every cancel would attempt clawback | Added `milestoneBonusOrderId` — only clawback if the cancelled order matches the bonus order |
| Clawback min balance not guarded | Wallet with 0 balance after spending bonus would go negative if clawed back | `Math.max(0, prevBalance - BONUS_AMOUNT)` |
| Helper required order object | Callers had to pass full populated order document. In merchant cancel endpoint, the order might be a plain document or ID only. | `resolveOrderObject()` accepts either full document or string ID — calls `Order.findById()` internally if needed |

---

### 🔄 Old vs. New (The Diff)

| Aspect | Before | After |
|--------|--------|-------|
| `Customer.customerDetails.milestoneBonusClaimed` | `Boolean`, default `false` | `String` enum: `"unclaimed"` / `"claimed"` / `"clawed_back"`, default `"unclaimed"` |
| `milestoneBonusOrderId` | Not present | `ObjectId` ref to `Order`, default `null` |
| Order completion flow | Nothing happens after completion logic | `creditMilestoneBonus(order)` fires — adds 50rs wallet + transaction log if eligible |
| Admin cancel flow | No bonus-related logic | `clawbackMilestoneBonus(order)` fires — deducts 50rs + debit log if conditions met |
| Merchant cancel flow | No bonus-related logic | `clawbackMilestoneBonus(order)` fires — same logic |
| Backward compat | N/A | Normalization handles old `false`/`true`/`undefined` values — no migration needed |
| Exploit protection | N/A | Once clawed back, status set to `"clawed_back"` — cannot re-claim. Cancel-reorder loop blocked. |

---

### Testing Scenarios for QA

**Prerequisites:** Running server, MongoDB, admin JWT token, merchant JWT token, a customer with wallet 0 and no bonus claimed, an order with grandTotal >= 300.

| # | Test Case | Steps | Expected Result | Verification |
|---|-----------|-------|-----------------|--------------|
| 1 | Bonus credited on completion | POST `/api/admin/order/:id/complete` with admin token | Console `[BONUS] Credited 50rs`. Wallet +50. Status `"claimed"`. BonusOrderId set. | Check DB + console logs |
| 2 | Order under 300 — no bonus | Complete order with grandTotal 250 | No bonus log. Wallet unchanged. No transaction. | Check DB + console |
| 3 | No second bonus | After test 1, complete another order ≥300 for same customer | No bonus log. Wallet unchanged from test 1 result. | Check DB |
| 4 | Admin clawback on cancel | Cancel the bonus order from test 1 via admin | Console `[BONUS] Clawed back 50rs`. Wallet back to pre-bonus. Status `"clawed_back"`. Debit transaction created. | Check DB |
| 5 | Merchant clawback on cancel | Repeat test 1-4 using merchant endpoint | Same as test 4 | Check DB |
| 6 | Cancel different order — no clawback | After test 4, cancel a different order | No clawback log. Wallet unchanged. | Check console |
| 7 | Old customer with `false` in DB | Find customer with `milestoneBonusClaimed: false`. Complete order ≥300. | Bonus works. Field auto-updates to `"claimed"`. | Check DB |
| 8 | Clawback on already-clawed order | Cancel the same order again | No clawback — status already `"clawed_back"`, not `"claimed"` | Check console |
| 9 | Bonus order ID mismatch | Some other customer's bonus order gets cancelled | No effect — milestoneBonusOrderId doesn't match | Check console |
| 10 | Wallet at 0 + clawback | Customer spent the 50rs bonus, wallet is 0. Cancel the bonus order. | Wallet stays at 0 (not negative). Clawback logged. | Check DB balance ≥ 0 |

**MongoDB verification commands:**
```javascript
// All customers with non-default bonus status
db.Customers.find(
  { "customerDetails.milestoneBonusClaimed": { $ne: "unclaimed" } },
  { _id: 1, "customerDetails.walletBalance": 1, "customerDetails.milestoneBonusClaimed": 1, "customerDetails.milestoneBonusOrderId": 1 }
)

// Transaction log for a specific order
db.CustomerWalletTransactions.find({ orderId: "<order_id>" }).sort({ date: -1 })
```