### PR TITLE
fix:(cashbackNotBeingProvidedForHappypath)

### DIFF
--- a/controllers/customer/pickAndDropController.js
+++ b/controllers/customer/pickAndDropController.js
@@ -1206,6 +1206,7 @@ const {
   razorpayRefund,
 } = require("../../utils/razorpayPayment");
 const { formatDate, formatTime } = require("../../utils/formatters");
+const { creditMilestoneBonus } = require("../../utils/firstOrderBonusHelper");
 const {
   uploadToFirebase,
   deleteFromFirebase,
@@ -1721,6 +1722,14 @@ const confirmPickAndDropController = async (req, res, next) => {
           success: true,
           orderId: newOrder._id,
           createdAt: null,
+          walletBalance: customer.customerDetails.walletBalance.toFixed(2),
+        });
+
+        // Fire-and-forget: credit milestone bonus — non-blocking, never throws
+        setImmediate(() => {
+          creditMilestoneBonus(newOrder._id).catch(err =>
+            console.error("[BONUS] async credit failed:", err.message)
+          );
         });
 
         await sendSocketDataAndNotification({
@@ -1782,6 +1791,7 @@ const confirmPickAndDropController = async (req, res, next) => {
         success: true,
         orderId,
         createdAt: tempOrder.createdAt,
+        walletBalance: customer.customerDetails.walletBalance.toFixed(2),
       });
     } else if (paymentMode === "Online-payment") {
       const { success, orderId: razorpayOrderId, error } =
@@ -1842,6 +1852,7 @@ const confirmPickAndDropController = async (req, res, next) => {
         orderId,
         razorpayOrderId,
         amount: orderAmount,
+        walletBalance: customer.customerDetails.walletBalance.toFixed(2),
       });
     }
   } catch (err) {

--- a/controllers/customer/universalOrderController.js
+++ b/controllers/customer/universalOrderController.js
@@ -37,6 +37,7 @@ const {
 } = require("../../utils/razorpayPayment");
 const { formatDate, formatTime } = require("../../utils/formatters");
 const appError = require("../../utils/appError");
+const { creditMilestoneBonus } = require("../../utils/firstOrderBonusHelper");
 const { geoLocation } = require("../../utils/getGeoLocation");
 const {
   validateDeliveryOption,
@@ -2316,6 +2317,14 @@ const orderPaymentController = async (req, res, next) => {
           createdAt: newOrder.createdAt,
           merchantName: merchant.merchantDetail.merchantName,
           deliveryMode: newOrder.deliveryMode,
+          walletBalance: customer.customerDetails.walletBalance.toFixed(2),
+        });
+
+        // Fire-and-forget: credit milestone bonus — non-blocking, never throws
+        setImmediate(() => {
+          creditMilestoneBonus(newOrder._id).catch(err =>
+            console.error("[BONUS] async credit failed:", err.message)
+          );
         });
 
         // Send notifications to each role dynamically
@@ -2378,6 +2387,7 @@ const orderPaymentController = async (req, res, next) => {
           createdAt: tempOrder.createdAt,
           merchantName: merchant.merchantDetail.merchantName,
           deliveryMode: tempOrder.deliveryMode,
+          walletBalance: customer.customerDetails.walletBalance.toFixed(2),
         });
         // NOTE: Cron worker (index.js) creates the final Order after expiresAt
         // and handles CustomerTransaction, PromoCode, ActivityLog, notifications
@@ -2437,6 +2447,7 @@ const orderPaymentController = async (req, res, next) => {
         createdAt: tempOrder.createdAt,
         merchantName: merchant.merchantDetail.merchantName,
         deliveryMode: tempOrder.deliveryMode,
+        walletBalance: customer.customerDetails.walletBalance.toFixed(2),
       });
       // NOTE: Cron worker (index.js) creates the final Order after expiresAt
       // and handles CustomerTransaction, PromoCode, ActivityLog, notifications
@@ -2491,6 +2502,7 @@ const orderPaymentController = async (req, res, next) => {
         orderId,
         razorpayOrderId,
         amount: orderAmount,
+        walletBalance: customer.customerDetails.walletBalance.toFixed(2),
       });
     }
 

--- a/utils/ProcessOrderService.js
+++ b/utils/ProcessOrderService.js
@@ -10,6 +10,7 @@ const ActivityLog = require("../models/ActivityLog");
 const CustomerTransaction = require("../models/CustomerTransactionDetail");
 const PickAndCustomCart = require("../models/PickAndCustomCart");
 const DatabaseCounter = require("../models/DatabaseCounter");
+const { creditMilestoneBonus } = require("./firstOrderBonusHelper");
 
 const processOrderService = async (tempOrder) => {
   const session = await mongoose.startSession();
@@ -177,6 +178,13 @@ const processOrderService = async (tempOrder) => {
     );
 
     await session.commitTransaction();
+
+    // Fire-and-forget: credit milestone bonus — non-blocking, never throws
+    setImmediate(() => {
+      creditMilestoneBonus(finalOrder._id).catch(err =>
+        console.error("[BONUS] async credit failed:", err.message)
+      );
+    });
 
     return finalOrder;
   } catch (err) {


### PR DESCRIPTION
## Summary

The ₹50 milestone bonus (`creditMilestoneBonus`) was only firing on the admin "mark complete" action — a back-office button admins rarely use. Every other order completion path (wallet payments, cron-processed orders, pick & drop) silently bypassed it. The bonus logic was correct, but unreachable for the vast majority of real orders.

## Fix

Wired `creditMilestoneBonus` into all remaining order completion flows using the same fire-and-forget `setImmediate` pattern already used in admin mark-complete. Also added `clawbackMilestoneBonus` to merchant-side cancellation to prevent cancel-reorder exploits.

## Flows affected

| Flow | File | Change |
|------|------|--------|
| Wallet instant (Famto-cash) | `universalOrderController.js` | Added `setImmediate` call after response |
| Cron-processed (non-wallet) | `ProcessOrderService.js` | Added `setImmediate` call after transaction commit |
| Pick & Drop | `pickAndDropController.js` | Added `setImmediate` call after response |
| Admin mark-complete | `adminOrderController.js` | Already wired (no change) |
| Admin cancel (clawback) | `adminOrderController.js` | Already wired (no change) |
| Merchant cancel (clawback) | `merchantOrderController.js` | Added clawback call |