### PR TITLE
showTaxSplitUp

### DIFF
--- a/controllers/admin/order/adminOrderController.js
+++ b/controllers/admin/order/adminOrderController.js
@@ -2137,6 +2137,7 @@ const createInvoiceByAdminController = async (req, res, next) => {
       surgeCharges,
       deliveryChargeForScheduledOrder,
       taxAmount,
+      taxComponents,
       itemTotal,
       returnCharge,
     } = await calculateDeliveryChargeHelperForAdmin(
@@ -2171,6 +2172,7 @@ const createInvoiceByAdminController = async (req, res, next) => {
       taxAmount || 0,
       addedTip || 0,
       returnCharge || 0,
+      taxComponents
     );
 
     console.log("Bill detail:", billDetail);

--- a/controllers/admin/order/merchantOrderController.js
+++ b/controllers/admin/order/merchantOrderController.js
@@ -2339,6 +2339,7 @@ const createInvoiceController = async (req, res, next) => {
       surgeCharges,
       deliveryChargeForScheduledOrder,
       taxAmount,
+      taxComponents,
       itemTotal,
       returnCharge,
     } = await calculateDeliveryChargesHelper({
@@ -2370,6 +2371,7 @@ const createInvoiceController = async (req, res, next) => {
       taxAmount || 0,
       addedTip,
       returnCharge || 0,
+      taxComponents
     );
 
     let customerCart;
@@ -2696,6 +2698,7 @@ const createOrderFromExternalMerchant = async (req, res, next) => {
     }, 0);
 
     let taxAmount = 0;
+    let taxComponents = [];
     if (customerTax) {
       const taxPercentage = customerTax.tax;
 
@@ -2703,6 +2706,12 @@ const createOrderFromExternalMerchant = async (req, res, next) => {
         (parseFloat(deliveryCharge + surgeCharge) * taxPercentage) / 100;
 
       taxAmount = parseFloat(tax.toFixed(2));
+      taxComponents = [{
+        taxName: customerTax.taxName,
+        taxRate: customerTax.tax,
+        taxType: customerTax.taxType,
+        amount: taxAmount,
+      }];
     }
 
     const deliveryTime = new Date(
@@ -2730,6 +2739,7 @@ const createOrderFromExternalMerchant = async (req, res, next) => {
         deliveryChargePerDay: deliveryCharge,
         deliveryCharge,
         taxAmount,
+        taxComponents,
         grandTotal: itemTotal + deliveryCharge + surgeCharge + taxAmount,
         itemTotal,
         subTotal: itemTotal + deliveryCharge + surgeCharge,

--- a/controllers/customer/customOrderController.js
+++ b/controllers/customer/customOrderController.js
@@ -459,9 +459,16 @@ const addDeliveryAddressController = async (req, res, next) => {
     }
 
     let taxAmount = 0;
+    let taxComponents = [];
     if (taxFound && taxFound.status) {
       const calculatedTax = (updatedDeliveryCharges * taxFound.tax) / 100;
       taxAmount = parseFloat(calculatedTax.toFixed(2));
+      taxComponents = [{
+        taxName: taxFound.taxName,
+        taxRate: taxFound.tax,
+        taxType: taxFound.taxType,
+        amount: taxAmount,
+      }];
     }
 
     updatedBillDetail = {
@@ -478,6 +485,7 @@ const addDeliveryAddressController = async (req, res, next) => {
       subTotal: null,
       vehicleType: null,
       taxAmount,
+      taxComponents,
       surgePrice: Math.round(updatedSurgeCharges) || null,
     };
 
@@ -565,6 +573,7 @@ const confirmCustomOrderController = async (req, res, next) => {
         cart.billDetail.discountedDeliveryCharge ||
         cart.billDetail.originalDeliveryCharge,
       taxAmount: cart.billDetail.taxAmount,
+      taxComponents: cart.billDetail.taxComponents || [],
       discountedAmount: cart.billDetail.discountedAmount,
       promoCodeUsed: cart.billDetail.promoCodeUsed,
       surgePrice: cart.billDetail.surgePrice,

--- a/controllers/customer/pickAndDropController.js
+++ b/controllers/customer/pickAndDropController.js
@@ -1509,9 +1509,16 @@ const confirmPickAndDropVehicleType = async (req, res, next) => {
     const taxFound = await Tax.findById(taxId);
 
     let taxAmount = 0;
+    let taxComponents = [];
     if (taxFound && taxFound.status) {
       const calculatedTax = (deliveryCharges * taxFound.tax) / 100;
       taxAmount = parseFloat(calculatedTax.toFixed(2));
+      taxComponents = [{
+        taxName: taxFound.taxName,
+        taxRate: taxFound.tax,
+        taxType: taxFound.taxType,
+        amount: taxAmount,
+      }];
     }
 
     const originalDeliveryCharge = Math.round(deliveryCharges - surgeCharges);
@@ -1519,6 +1526,7 @@ const confirmPickAndDropVehicleType = async (req, res, next) => {
 
     cart.billDetail = {
       taxAmount,
+      taxComponents,
       originalDeliveryCharge,
       vehicleType,
       originalGrandTotal,
@@ -1561,6 +1569,7 @@ const getPickAndDropBill = async (req, res, next) => {
       discountedAmount: cart?.billDetail?.discountedAmount || null,
       promoCodeUsed: cart?.billDetail?.promoCodeUsed || null,
       taxAmount: cart?.billDetail?.taxAmount || null,
+      taxComponents: cart?.billDetail?.taxComponents || [],
       grandTotal: cart?.billDetail?.discountedAmount
         ? cart.billDetail.discountedGrandTotal
         : cart?.billDetail?.originalGrandTotal,

--- a/controllers/customer/universalOrderController.js
+++ b/controllers/customer/universalOrderController.js
@@ -1970,6 +1970,7 @@ const confirmOrderDetailController = async (req, res, next) => {
       surgeCharges,
       deliveryChargeForScheduledOrder,
       taxAmount,
+      taxComponents,
       itemTotal,
       returnCharge,
     } = await calculateDeliveryChargesHelper({
@@ -2029,6 +2030,7 @@ const confirmOrderDetailController = async (req, res, next) => {
       taxAmount || 0,
       cart?.billDetail?.addedTip || 0,
       returnCharge || 0,
+      taxComponents
     );
 
     const customerCart = await CustomerCart.findOneAndUpdate(
@@ -2192,6 +2194,7 @@ const orderPaymentController = async (req, res, next) => {
         cart.billDetail.discountedDeliveryCharge ||
         cart.billDetail.originalDeliveryCharge,
       taxAmount: cart.billDetail.taxAmount,
+      taxComponents: cart.billDetail.taxComponents || [],
       discountedAmount: cart.billDetail.discountedAmount,
       promoCodeUsed: cart.billDetail.promoCodeUsed,
       grandTotal:

--- a/models/CustomerCart.js
+++ b/models/CustomerCart.js
@@ -169,6 +169,22 @@ const billSchema = mongoose.Schema(
       type: Number,
       default: null,
     },
+    taxComponents: {
+      type: [
+        {
+          taxName: { type: String, required: true },
+          taxRate: { type: Number, required: true },
+          taxType: {
+            type: String,
+            enum: ["Fixed-amount", "Percentage"],
+            required: true,
+          },
+          amount: { type: Number, required: true },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
   },
   {
     _id: false,

--- a/models/Order.js
+++ b/models/Order.js
@@ -71,6 +71,22 @@ const billSchema = mongoose.Schema(
     promoCodeUsed: { type: String, default: null },
     promoCodeDiscount: { type: Number, default: null },
     returnCharge: { type: Number, default: null },
+    taxComponents: {
+      type: [
+        {
+          taxName: { type: String, required: true },
+          taxRate: { type: Number, required: true },
+          taxType: {
+            type: String,
+            enum: ["Fixed-amount", "Percentage"],
+            required: true,
+          },
+          amount: { type: Number, required: true },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
   },
   { _id: false }
 );

--- a/models/PickAndCustomCart.js
+++ b/models/PickAndCustomCart.js
@@ -69,6 +69,22 @@ const billSchema = mongoose.Schema(
     taxAmount: { type: Number, default: null },
     promoCodeUsed: { type: String, default: null },
     promoCodeDiscount: { type: Number, default: null },
+    taxComponents: {
+      type: [
+        {
+          taxName: { type: String, required: true },
+          taxRate: { type: Number, required: true },
+          taxType: {
+            type: String,
+            enum: ["Fixed-amount", "Percentage"],
+            required: true,
+          },
+          amount: { type: Number, required: true },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
   },
   { _id: false }
 );

--- a/models/ScheduledOrder.js
+++ b/models/ScheduledOrder.js
@@ -43,6 +43,22 @@ const billSchema = mongoose.Schema(
       type: Number,
       default: 0,
     },
+    taxComponents: {
+      type: [
+        {
+          taxName: { type: String, required: true },
+          taxRate: { type: Number, required: true },
+          taxType: {
+            type: String,
+            enum: ["Fixed-amount", "Percentage"],
+            required: true,
+          },
+          amount: { type: Number, required: true },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
     discountedAmount: {
       type: Number,
       default: null,

--- a/models/TemporaryOrder.js
+++ b/models/TemporaryOrder.js
@@ -100,6 +100,22 @@ const billSchema = mongoose.Schema(
     taxAmount: { type: Number, default: null },
     promoCodeUsed: { type: String, default: null },
     promoCodeDiscount: { type: Number, default: null },
+    taxComponents: {
+      type: [
+        {
+          taxName: { type: String, required: true },
+          taxRate: { type: Number, required: true },
+          taxType: {
+            type: String,
+            enum: ["Fixed-amount", "Percentage"],
+            required: true,
+          },
+          amount: { type: Number, required: true },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
   },
   { _id: false }
 );

--- a/utils/createOrderHelpers.js
+++ b/utils/createOrderHelpers.js
@@ -807,6 +807,7 @@ const calculateDeliveryChargesHelper = async ({
   let surgeCharges = null;
   let deliveryChargeForScheduledOrder = null;
   let taxAmount = null;
+  let taxComponents = [];
   let returnCharge = null;
 
   const itemTotal = ["Take Away", "Home Delivery"].includes(deliveryMode)
@@ -903,12 +904,15 @@ const calculateDeliveryChargesHelper = async ({
     }
 
     console.log("🧾 Calculating Tax...");
-    taxAmount = await getTaxAmount(
+    const taxResult = await getTaxAmount(
       businessCategoryId,
       merchant.merchantDetail.geofenceId,
       itemTotal,
       deliveryChargeForScheduledOrder || oneTimeDeliveryCharge
     );
+    const { taxComponents: homeDeliveryTaxComponents, totalTax: homeDeliveryTotalTax } = taxResult;
+    taxAmount = homeDeliveryTotalTax;
+    taxComponents = homeDeliveryTaxComponents;
 
     console.log("💸 Tax Amount:", taxAmount);
   }
@@ -1005,8 +1009,15 @@ const calculateDeliveryChargesHelper = async ({
     if (taxFound) {
       const calculatedTax = (charge * taxFound.tax) / 100;
       taxAmount = parseFloat(calculatedTax.toFixed(2));
-
+      taxComponents = [{
+        taxName: taxFound.taxName,
+        taxRate: taxFound.tax,
+        taxType: taxFound.taxType,
+        amount: taxAmount,
+      }];
       console.log("💸 Tax Amount:", taxAmount);
+    } else {
+      taxComponents = [];
     }
   }
 
@@ -1025,6 +1036,12 @@ const calculateDeliveryChargesHelper = async ({
       if (taxFound) {
         const calculatedTax = (itemTotal * taxFound.tax) / 100;
         taxAmount = parseFloat(calculatedTax.toFixed(2));
+        taxComponents = [{
+          taxName: taxFound.taxName,
+          taxRate: taxFound.tax,
+          taxType: taxFound.taxType,
+          amount: taxAmount,
+        }];
         console.log("💸 Take Away Tax Amount:", taxAmount);
       }
     }
@@ -1046,6 +1063,7 @@ const calculateDeliveryChargesHelper = async ({
     surgeCharges,
     deliveryChargeForScheduledOrder,
     taxAmount,
+    taxComponents,
     itemTotal,
     returnCharge,
   };
@@ -1114,7 +1132,8 @@ const calculateBill = (
   merchantDiscountAmount,
   taxAmount,
   addedTip = 0,
-  returnCharge = 0
+  returnCharge = 0,
+  taxComponents = []
 ) => {
   // Calculate total discount amount once
   const totalDiscountAmount =
@@ -1149,6 +1168,7 @@ const calculateBill = (
     addedTip,
     subTotal: parseFloat(subTotal).toFixed(2),
     taxAmount: parseFloat(taxAmount).toFixed(2),
+    taxComponents,
     surgePrice: surgeCharges || null,
     discountedAmount: totalDiscountAmount > 0 ? totalDiscountAmount : null,
     originalGrandTotal: Math.round(grandTotal),
@@ -1475,6 +1495,7 @@ const calculateDeliveryChargeHelperForAdmin = async (
       const takeAwayItemTotal = calculateItemTotal(items, scheduledDetails?.numOfDays);
 
       let takeAwayTaxAmount = 0;
+      let takeAwayTaxComponents = [];
 
       const appCustomization = await CustomerAppCustomization.findOne({}).select(
         "takeAwayOrderCustomization"
@@ -1487,6 +1508,12 @@ const calculateDeliveryChargeHelperForAdmin = async (
           takeAwayTaxAmount = parseFloat(
             ((takeAwayItemTotal * taxFound.tax) / 100).toFixed(2)
           );
+          takeAwayTaxComponents = [{
+            taxName: taxFound.taxName,
+            taxRate: taxFound.tax,
+            taxType: taxFound.taxType,
+            amount: takeAwayTaxAmount,
+          }];
         }
       }
 
@@ -1495,6 +1522,7 @@ const calculateDeliveryChargeHelperForAdmin = async (
         surgeCharges: 0,
         deliveryChargeForScheduledOrder: 0,
         taxAmount: takeAwayTaxAmount,
+        taxComponents: takeAwayTaxComponents,
         itemTotal: takeAwayItemTotal,
       };
     }
@@ -1667,9 +1695,16 @@ const pickAndDropCharges = async (
   const charge = deliveryChargeForScheduledOrder ?? oneTimeDeliveryCharge;
 
   let taxAmount = 0;
+  let taxComponents = [];
   if (taxFound) {
     const calculatedTax = (charge * taxFound.tax) / 100;
     taxAmount = parseFloat(calculatedTax.toFixed(2));
+    taxComponents = [{
+      taxName: taxFound.taxName,
+      taxRate: taxFound.tax,
+      taxType: taxFound.taxType,
+      amount: taxAmount,
+    }];
   }
 
   return {
@@ -1677,6 +1712,7 @@ const pickAndDropCharges = async (
     surgeCharges: surgeCharges || null,
     deliveryChargeForScheduledOrder: deliveryChargeForScheduledOrder || null,
     taxAmount,
+    taxComponents,
     itemTotal: null,
     returnCharge,
   };
@@ -1763,9 +1799,16 @@ const customOrderCharges = async (
   const charge = deliveryChargeForScheduledOrder || oneTimeDeliveryCharge;
 
   let taxAmount = 0;
+  let taxComponents = [];
   if (taxFound) {
     const calculatedTax = (charge * taxFound.tax) / 100;
     taxAmount = parseFloat(calculatedTax.toFixed(2));
+    taxComponents = [{
+      taxName: taxFound.taxName,
+      taxRate: taxFound.tax,
+      taxType: taxFound.taxType,
+      amount: taxAmount,
+    }];
   }
 
   return {
@@ -1775,6 +1818,7 @@ const customOrderCharges = async (
       ? deliveryChargeForScheduledOrder
       : 0,
     taxAmount,
+    taxComponents,
     itemTotal: 0,
   };
 };

--- a/utils/customerAppHelpers.js
+++ b/utils/customerAppHelpers.js
@@ -269,16 +269,32 @@ const getTaxAmount = async (
       assignToBusinessCategory: businessCategoryId,
       geofences: { $in: [geofenceId] },
       status: true,
+    }).lean();
+
+    if (!taxesFound.length) {
+      return { taxComponents: [], totalTax: 0 };
+    }
+
+    const taxComponents = taxesFound.map((t) => {
+      let amount = 0;
+      if (t.taxType === "Fixed-amount") {
+        amount = t.tax;
+      } else {
+        amount = (parseFloat(itemTotal) * t.tax) / 100;
+      }
+      return {
+        taxName: t.taxName,
+        taxRate: t.tax,
+        taxType: t.taxType,
+        amount: parseFloat(amount.toFixed(2)),
+      };
     });
 
-    if (!taxesFound.length) throw new Error("Tax not found");
+    const totalTax = parseFloat(
+      taxComponents.reduce((sum, c) => sum + c.amount, 0).toFixed(2)
+    );
 
-    const taxAmount = taxesFound.reduce((sum, t) => {
-      if (t.taxType === "Fixed-amount") return sum + t.tax;
-      return sum + (parseFloat(itemTotal) * t.tax) / 100;
-    }, 0);
-
-    return parseFloat(taxAmount.toFixed(2));
+    return { taxComponents, totalTax };
   } catch (err) {
     throw new Error(err.message);
   }


### PR DESCRIPTION
# Tax Component Split — Implementation Guide

> **Date:** 2026-07-24
> **Author:** Adithyan

---

## Table of Contents

1. [Instructions for Frontend Developers](#-instructions-for-frontend-developers)
2. [What Was Wrong](#-what-was-wrong)
3. [How We Fixed It](#-how-we-fixed-it)
4. [Old Code vs New Code — Side by Side](#-old-code-vs-new-code--side-by-side)
5. [File Change Inventory](#-file-change-inventory)
6. [Testing & Rollback](#-testing--rollback)

---

## 📱 Instructions for Frontend Developers

### What Changed

Every API response that returns a bill/order now includes a new field `taxComponents` alongside the existing `taxAmount`.

**Before:**
```json
{
  "taxAmount": 180.00,
  "grandTotal": 1230
}
```

**After:**
```json
{
  "taxAmount": 180.00,
  "taxComponents": [
    { "taxName": "CGST",     "taxRate": 9,  "taxType": "Percentage",   "amount": 90.00 },
    { "taxName": "SGST",     "taxRate": 9,  "taxType": "Percentage",   "amount": 90.00 }
  ],
  "grandTotal": 1230
}
```

### What You Need to Do

#### 1. Replace single-line tax display with a component list

**Old code (one row):**
```jsx
<tr>
  <td>Taxes & Fees</td>
  <td>₹{billDetail.taxAmount ?? 0}</td>
</tr>
```

**New code (expanded):**
```jsx
{billDetail.taxComponents?.length > 0 ? (
  <>
    {billDetail.taxComponents.map((tc, i) => (
      <tr key={i}>
        <td>{tc.taxName} @ {tc.taxRate}%</td>
        <td>₹{tc.amount.toFixed(2)}</td>
      </tr>
    ))}
    <tr className="total-tax">
      <td>Total Tax</td>
      <td>₹{billDetail.taxAmount}</td>
    </tr>
  </>
) : (
  <tr>
    <td>Taxes & Fees</td>
    <td>₹{billDetail.taxAmount ?? 0}</td>
  </tr>
)}
```

#### 2. Response fields reference

| Field | Type | Always present? | Notes |
|---|---|---|---|
| `taxAmount` | `number` (string) | ✅ Yes | Sum of all components. Same as before. |
| `taxComponents` | `array` | ✅ Yes (empty if none) | New field. |
| `taxComponents[].taxName` | `string` | ✅ Yes | e.g. `"CGST"`, `"SGST"`, `"Service Tax"` |
| `taxComponents[].taxRate` | `number` | ✅ Yes | The rate as a number (e.g. `9` for 9%) |
| `taxComponents[].taxType` | `string` | ✅ Yes | `"Percentage"` or `"Fixed-amount"` |
| `taxComponents[].amount` | `number` | ✅ Yes | Computed amount in rupees |

#### 3. Which endpoints are affected

Every endpoint that returns a `billDetail` block:

| Endpoint | What changed |
|---|---|
| **Order creation** (all delivery modes) | `taxComponents` in response |
| **Bill preview** (get bill before order) | `taxComponents` in response |
| **Order detail** (single order view) | `taxComponents` in `billDetail` |
| **Order list** (admin/merchant) | `taxComponents` not in flattened list view — only the full detail |
| **Temporary order** (pre-payment) | `taxComponents` in `billDetail` |

#### 4. Edge cases to handle in UI

| Scenario | `taxComponents` value | What to show |
|---|---|---|
| No taxes configured | `[]` | Show single "Taxes & Fees: ₹0" row |
| Single tax (e.g. GST 18%) | `[{taxName:"GST", amount:180}]` | Show "GST @ 18%: ₹180" |
| Multiple taxes (CGST + SGST) | `[{...},{...}]` | Show each on its own row + total |
| Mixed percentage + fixed | `[{taxType:"Percentage",...},{taxType:"Fixed-amount",...}]` | Show "Fixed Fee: ₹20" as a line item |
| Legacy order (before this change) | `undefined` or missing | Fall back to `taxAmount` display |

**Safe fallback pattern:**
```jsx
const components = billDetail.taxComponents;
if (components?.length) {
  // render expanded rows
} else {
  // render old single row
}
```

#### 5. JSON-LD / receipt / invoice generation

If you generate invoices or structured data, the `taxComponents` array maps directly to the `"tax"` section of a GST invoice:

```json
{
  "taxComponents": [
    { "taxName": "CGST", "taxRate": 9, "amount": 90.00 },
    { "taxName": "SGST", "taxRate": 9, "amount": 90.00 }
  ]
}
```

---

## ❌ What Was Wrong

### The Problem

The system supported **multiple active taxes** per business category and geofence. An admin could configure:

- CGST 9%
- SGST 9%
- Service Tax 10%

...all on the same category. And the backend **did query all of them** from the database. But then it **reduced them to a single number** and discarded the names.

### The Bad Code (Root Cause)

In `utils/customerAppHelpers.js`, the function `getTaxAmount()`:

```js
const taxesFound = await Tax.find({
  assignToBusinessCategory: businessCategoryId,
  geofences: { $in: [geofenceId] },
  status: true,
});
// taxesFound = [
//   { taxName: "CGST", tax: 9 },
//   { taxName: "SGST", tax: 9 }
// ]

const taxAmount = taxesFound.reduce((sum, t) => {
  if (t.taxType === "Fixed-amount") return sum + t.tax;
  return sum + (parseFloat(itemTotal) * t.tax) / 100;
}, 0);
// taxAmount = 180 — SUM only, names GONE

return parseFloat(taxAmount.toFixed(2));
// Returns: 180
```

The data existed in MongoDB. The `Tax` model (`models/Tax.js`) always stored `taxName: "CGST"`. But `getTaxAmount` threw away `t.taxName` by reducing the array to one number.

### Downstream Impact

Every layer downstream of `getTaxAmount` only ever saw a single number:

```
getTaxAmount() → 180

calculateDeliveryChargesHelper() → { taxAmount: 180 }

calculateBill() → { taxAmount: "180.00" }

Cart.billDetail → { taxAmount: 180 }

Order.billDetail → { taxAmount: 180 }

API response → { "taxAmount": 180 }

Frontend → "Taxes & Fees: ₹180"
```

No one knew that ₹180 was CGST ₹90 + SGST ₹90.

### Schemas Were Missing the Field

Every `billSchema` embedded subdocument in CustomerCart, PickAndCustomCart, Order, TemporaryOrder, and ScheduledOrder had a single `taxAmount: Number` field — no room for components.

### Different Delivery Modes Had Different Tax Paths

| Mode | Tax Source | Could have multiple taxes? | Was splitting? |
|---|---|---|---|
| Home Delivery | `Tax.find({assignToBusinessCategory, geofence})` | ✅ Yes (2+ taxes) | ❌ No |
| Pick & Drop | Single tax from app config | ❌ Always 1 | ❌ No |
| Take Away | Single tax from app config | ❌ Always 1 | ❌ No |
| Custom Order | Single tax from app config | ❌ Always 1 | ❌ No |

Home Delivery was the worst offender — it could find CGST + SGST + Service Tax, compute them correctly, then flatten them into one number.

---

## ✅ How We Fixed It

### Strategy

Three-part change, **backward compatible**:

1. **Schemas:** Added `taxComponents` array field to every `billSchema` (default: `[]`)
2. **Core function:** `getTaxAmount()` now returns `{ taxComponents: [...], totalTax: Number }` instead of `Number`
3. **Propagation:** Every function and controller that touches tax now passes `taxComponents` through the pipeline

### Key Design Decisions

| Decision | Rationale |
|---|---|
| **Keep `taxAmount` as sum** | Zero frontend breakage. Old code still works. |
| **Add `taxComponents` as new field** | Frontend adopts at own pace — no migration needed. |
| **`taxComponents` is an array** | Extensible for N taxes. Render is a `.map()`. |
| **No `_id` on subdocuments** | Tax components don't need independent identity. |
| **Default `[]` on schemas** | Legacy orders have `taxComponents: undefined` → frontend falls back to `taxAmount`. |

---

## 📂 Old Code vs New Code — Side by Side

### 1. Schema (5 files)

```diff
 // billSchema in CustomerCart, PickAndCustomCart, Order, TemporaryOrder
 {
   taxAmount: { type: Number, default: null },
+  taxComponents: {
+    type: [{
+      taxName: { type: String, required: true },
+      taxRate: { type: Number, required: true },
+      taxType: { type: String, enum: ["Fixed-amount", "Percentage"], required: true },
+      amount: { type: Number, required: true },
+      _id: false,
+    }],
+    default: [],
+  },
 }
```

### 2. getTaxAmount() — The Core Fix

```diff
 // utils/customerAppHelpers.js

-return parseFloat(taxAmount.toFixed(2));
+const taxComponents = taxesFound.map((t) => {
+  let amount = t.taxType === "Fixed-amount"
+    ? t.tax
+    : (parseFloat(itemTotal) * t.tax) / 100;
+  return {
+    taxName: t.taxName,
+    taxRate: t.tax,
+    taxType: t.taxType,
+    amount: parseFloat(amount.toFixed(2)),
+  };
+});
+const totalTax = parseFloat(
+  taxComponents.reduce((sum, c) => sum + c.amount, 0).toFixed(2)
+);
+return { taxComponents, totalTax };
```

### 3. calculateBill() — Passing Through

```diff
 const calculateBill = (..., taxAmount, addedTip = 0, returnCharge = 0,
+  taxComponents = []
 ) => {
   return {
     ...
     taxAmount: parseFloat(taxAmount).toFixed(2),
+    taxComponents,
     ...
   };
 };
```

### 4. Controller Response — Including Components

```diff
 let orderBill = {
   deliveryCharge: ...,
   taxAmount: cart.billDetail.taxAmount,
+  taxComponents: cart.billDetail.taxComponents || [],
   grandTotal: ...,
 };
```

### 5. Inline Tax Paths (Pick & Drop, Take Away, Custom Order)

```diff
 let taxAmount = 0;
+let taxComponents = [];
 if (taxFound && taxFound.status) {
   const calculatedTax = (charge * taxFound.tax) / 100;
   taxAmount = parseFloat(calculatedTax.toFixed(2));
+  taxComponents = [{
+    taxName: taxFound.taxName,
+    taxRate: taxFound.tax,
+    taxType: taxFound.taxType,
+    amount: taxAmount,
+  }];
 }
```

---

## 📋 File Change Inventory

| # | File | Change Type | Lines Changed |
|---|------|-------------|---------------|
| 1 | `models/CustomerCart.js` | Schema: added `taxComponents` | +16 |
| 2 | `models/PickAndCustomCart.js` | Schema: added `taxComponents` | +16 |
| 3 | `models/Order.js` | Schema: added `taxComponents` | +16 |
| 4 | `models/TemporaryOrder.js` | Schema: added `taxComponents` | +16 |
| 5 | `models/ScheduledOrder.js` | Schema: added `taxComponents` | +16 |
| 6 | `utils/customerAppHelpers.js` | Rewrote `getTaxAmount()` return shape | +19 / -8 |
| 7 | `utils/createOrderHelpers.js` | 6 functions updated (see below) | ~60 |
| 8 | `controllers/customer/universalOrderController.js` | Destructure + pass + response | +4 |
| 9 | `controllers/customer/customOrderController.js` | Inline calc + response | +13 |
| 10 | `controllers/customer/pickAndDropController.js` | Inline calc + bill response | +12 |
| 11 | `controllers/admin/order/adminOrderController.js` | Destructure + pass | +2 |
| 12 | `controllers/admin/order/merchantOrderController.js` | Destructure + pass + inline + order create | +8 |

**Total: 12 files modified. 0 frontend files changed.**

### Functions Updated in createOrderHelpers.js

| Function | Change |
|---|---|
| `calculateDeliveryChargesHelper` | Added `taxComponents` variable, set from Home Delivery / Pick & Drop / Take Away paths |
| `calculateBill` | Added `taxComponents` parameter, passed through to return |
| `calculateDeliveryChargeHelperForAdmin` | Take Away branch returns `taxComponents` |
| `pickAndDropCharges` | Returns `taxComponents` array |
| `customOrderCharges` | Returns `taxComponents` array |

---

## 🧪 Testing & Rollback

### How to Test

1. **Admin:** Configure two taxes on a business category (e.g. CGST 9% + SGST 9%)
2. **Customer:** Place an order in that category
3. **Verify API response** includes `taxComponents` with both entries and `taxAmount` as the sum
4. **Verify Dashboard** still renders the single "Taxes & Fees" row (old code)
5. **Verify old orders** still display correctly (they have `taxComponents: undefined` → fallback)

### Rollback Plan

This change is **safe to roll back** at any time because:

- `taxComponents` is additive — removing it from the schema doesn't break anything
- `taxAmount` is **unchanged** — it was never removed or renamed
- Frontends that don't read `taxComponents` see no difference
- Old orders in the database have `taxComponents: undefined` → frontend falls back gracefully

**To roll back:** Revert the 12 files using git.

---

## Business Category / Tax Assignment Flow

For context on how taxes connect to orders:

```
Admin creates Tax:
  { taxName: "CGST", tax: 9, taxType: "Percentage",
    geofences: [Mumbai], assignToBusinessCategory: [Groceries] }
         │
         ▼
BusinessCategory assigns to serviceId (Handyman / Delivery / etc.)
         │
         ▼
Order is placed with businessCategoryId + geofenceId
         │
         ▼
getTaxAmount(businessCategoryId, geofenceId, itemTotal)
  → Tax.find({ assignToBusinessCategory: categoryId, geofences: { $in: [geofenceId] }, status: true })
  → Returns { taxComponents: [...], totalTax }
```

The handyman service category uses the same `assignToBusinessCategory` relationship — if a tax document points to the same business category, it applies to handyman orders too. No special handyman tax logic needed.
