### PR TITLE
Bug/custom order outside geofence

### DIFF
--- a/controllers/admin/order/adminOrderController.js
+++ b/controllers/admin/order/adminOrderController.js
@@ -2137,6 +2137,7 @@ const createInvoiceByAdminController = async (req, res, next) => {
       surgeCharges,
       deliveryChargeForScheduledOrder,
       taxAmount,
+      taxComponents,
       itemTotal,
       returnCharge,
     } = await calculateDeliveryChargeHelperForAdmin(
@@ -2171,6 +2172,7 @@ const createInvoiceByAdminController = async (req, res, next) => {
       taxAmount || 0,
       addedTip || 0,
       returnCharge || 0,
+      taxComponents
     );
 
     console.log("Bill detail:", billDetail);

--- a/controllers/admin/order/merchantOrderController.js
+++ b/controllers/admin/order/merchantOrderController.js
@@ -2339,6 +2339,7 @@ const createInvoiceController = async (req, res, next) => {
       surgeCharges,
       deliveryChargeForScheduledOrder,
       taxAmount,
+      taxComponents,
       itemTotal,
       returnCharge,
     } = await calculateDeliveryChargesHelper({
@@ -2370,6 +2371,7 @@ const createInvoiceController = async (req, res, next) => {
       taxAmount || 0,
       addedTip,
       returnCharge || 0,
+      taxComponents
     );
 
     let customerCart;
@@ -2696,6 +2698,7 @@ const createOrderFromExternalMerchant = async (req, res, next) => {
     }, 0);
 
     let taxAmount = 0;
+    let taxComponents = [];
     if (customerTax) {
       const taxPercentage = customerTax.tax;
 
@@ -2703,6 +2706,12 @@ const createOrderFromExternalMerchant = async (req, res, next) => {
         (parseFloat(deliveryCharge + surgeCharge) * taxPercentage) / 100;
 
       taxAmount = parseFloat(tax.toFixed(2));
+      taxComponents = [{
+        taxName: customerTax.taxName,
+        taxRate: customerTax.tax,
+        taxType: customerTax.taxType,
+        amount: taxAmount,
+      }];
     }
 
     const deliveryTime = new Date(
@@ -2730,6 +2739,7 @@ const createOrderFromExternalMerchant = async (req, res, next) => {
         deliveryChargePerDay: deliveryCharge,
         deliveryCharge,
         taxAmount,
+        taxComponents,
         grandTotal: itemTotal + deliveryCharge + surgeCharge + taxAmount,
         itemTotal,
         subTotal: itemTotal + deliveryCharge + surgeCharge,

--- a/controllers/customer/customOrderController.js
+++ b/controllers/customer/customOrderController.js
@@ -459,9 +459,16 @@ const addDeliveryAddressController = async (req, res, next) => {
     }
 
     let taxAmount = 0;
+    let taxComponents = [];
     if (taxFound && taxFound.status) {
       const calculatedTax = (updatedDeliveryCharges * taxFound.tax) / 100;
       taxAmount = parseFloat(calculatedTax.toFixed(2));
+      taxComponents = [{
+        taxName: taxFound.taxName,
+        taxRate: taxFound.tax,
+        taxType: taxFound.taxType,
+        amount: taxAmount,
+      }];
     }
 
     updatedBillDetail = {
@@ -478,6 +485,7 @@ const addDeliveryAddressController = async (req, res, next) => {
       subTotal: null,
       vehicleType: null,
       taxAmount,
+      taxComponents,
       surgePrice: Math.round(updatedSurgeCharges) || null,
     };
 
@@ -565,6 +573,7 @@ const confirmCustomOrderController = async (req, res, next) => {
         cart.billDetail.discountedDeliveryCharge ||
         cart.billDetail.originalDeliveryCharge,
       taxAmount: cart.billDetail.taxAmount,
+      taxComponents: cart.billDetail.taxComponents || [],
       discountedAmount: cart.billDetail.discountedAmount,
       promoCodeUsed: cart.billDetail.promoCodeUsed,
       surgePrice: cart.billDetail.surgePrice,

--- a/controllers/customer/pickAndDropController.js
+++ b/controllers/customer/pickAndDropController.js
@@ -1207,6 +1207,7 @@ const {
 } = require("../../utils/razorpayPayment");
 const { formatDate, formatTime } = require("../../utils/formatters");
 const { creditMilestoneBonus } = require("../../utils/firstOrderBonusHelper");
+const { geoLocation } = require("../../utils/getGeoLocation");
 const {
   uploadToFirebase,
   deleteFromFirebase,
@@ -1396,10 +1397,38 @@ const getVehiclePricingDetailsController = async (req, res, next) => {
     );
     const uniqueVehicleTypes = [...new Set(vehicleTypes)];
 
+    // ── Geofence validation ─────────────────────────────────────────
+    // Resolve the customer's service area from the FIRST pickup location
+    // (the coordinates the user entered, not a stale registration value).
+    // This both validates the address is in service and correctly scopes
+    // pricing/surge lookups to the right geofence.
+    const firstPickup = cartFound.pickups?.[0];
+    if (
+      !firstPickup?.location ||
+      !Array.isArray(firstPickup.location) ||
+      firstPickup.location.length < 2
+    ) {
+      return next(
+        appError("Pickup location coordinates are missing or invalid", 400),
+      );
+    }
+
+    const [pickupLat, pickupLng] = firstPickup.location;
+    const resolvedGeofence = await geoLocation(pickupLat, pickupLng);
+
+    if (!resolvedGeofence) {
+      return next(
+        appError(
+          "Pickup location is outside our service area. Please choose a different pickup address.",
+          400,
+        ),
+      );
+    }
+
     // Fetch the customer pricing details for all vehicle types
     const customerPricingArray = await CustomerPricing.find({
       deliveryMode: "Pick and Drop",
-      geofenceId: customer.customerDetails.geofenceId,
+      geofenceId: resolvedGeofence._id,
       status: true,
       vehicleType: { $in: uniqueVehicleTypes },
     });
@@ -1409,7 +1438,7 @@ const getVehiclePricingDetailsController = async (req, res, next) => {
     }
 
     const customerSurge = await CustomerSurge.findOne({
-      geofenceId: customer.customerDetails.geofenceId,
+      geofenceId: resolvedGeofence._id,
       status: true,
     });
 

--- a/controllers/customer/pickAndDropController.js
+++ b/controllers/customer/pickAndDropController.js
@@ -1509,9 +1509,16 @@ const confirmPickAndDropVehicleType = async (req, res, next) => {
     const taxFound = await Tax.findById(taxId);
 
     let taxAmount = 0;
+    let taxComponents = [];
     if (taxFound && taxFound.status) {
       const calculatedTax = (deliveryCharges * taxFound.tax) / 100;
       taxAmount = parseFloat(calculatedTax.toFixed(2));
+      taxComponents = [{
+        taxName: taxFound.taxName,
+        taxRate: taxFound.tax,
+        taxType: taxFound.taxType,
+        amount: taxAmount,
+      }];
     }
 
     const originalDeliveryCharge = Math.round(deliveryCharges - surgeCharges);
@@ -1519,6 +1526,7 @@ const confirmPickAndDropVehicleType = async (req, res, next) => {
 
     cart.billDetail = {
       taxAmount,
+      taxComponents,
       originalDeliveryCharge,
       vehicleType,
       originalGrandTotal,
@@ -1561,6 +1569,7 @@ const getPickAndDropBill = async (req, res, next) => {
       discountedAmount: cart?.billDetail?.discountedAmount || null,
       promoCodeUsed: cart?.billDetail?.promoCodeUsed || null,
       taxAmount: cart?.billDetail?.taxAmount || null,
+      taxComponents: cart?.billDetail?.taxComponents || [],
       grandTotal: cart?.billDetail?.discountedAmount
         ? cart.billDetail.discountedGrandTotal
         : cart?.billDetail?.originalGrandTotal,

--- a/controllers/customer/universalOrderController.js
+++ b/controllers/customer/universalOrderController.js
@@ -1961,6 +1961,33 @@ const confirmOrderDetailController = async (req, res, next) => {
       newDeliveryAddress,
     );
 
+    // ── Geofence validation ─────────────────────────────────────────────
+    // Verify the delivery address falls inside at least one defined geofence.
+    // This blocks Home Delivery orders where the user's delivery address is
+    // outside the service area, even if they registered from a valid location.
+    if (deliveryMode === "Home Delivery") {
+      if (
+        !Array.isArray(deliveryLocation) ||
+        deliveryLocation.length < 2
+      ) {
+        return next(appError("Delivery location coordinates are missing", 400));
+      }
+
+      const deliveryGeofence = await geoLocation(
+        deliveryLocation[0],
+        deliveryLocation[1],
+      );
+
+      if (!deliveryGeofence) {
+        return next(
+          appError(
+            "Delivery address is outside our service area. Please choose a different address.",
+            400,
+          ),
+        );
+      }
+    }
+
     const cartItems = cart.items;
 
     const booleanSuperMarketOrder = isSuperMarketOrder === "true";

--- a/controllers/customer/universalOrderController.js
+++ b/controllers/customer/universalOrderController.js
@@ -1970,6 +1970,7 @@ const confirmOrderDetailController = async (req, res, next) => {
       surgeCharges,
       deliveryChargeForScheduledOrder,
       taxAmount,
+      taxComponents,
       itemTotal,
       returnCharge,
     } = await calculateDeliveryChargesHelper({
@@ -2029,6 +2030,7 @@ const confirmOrderDetailController = async (req, res, next) => {
       taxAmount || 0,
       cart?.billDetail?.addedTip || 0,
       returnCharge || 0,
+      taxComponents
     );
 
     const customerCart = await CustomerCart.findOneAndUpdate(
@@ -2192,6 +2194,7 @@ const orderPaymentController = async (req, res, next) => {
         cart.billDetail.discountedDeliveryCharge ||
         cart.billDetail.originalDeliveryCharge,
       taxAmount: cart.billDetail.taxAmount,
+      taxComponents: cart.billDetail.taxComponents || [],
       discountedAmount: cart.billDetail.discountedAmount,
       promoCodeUsed: cart.billDetail.promoCodeUsed,
       grandTotal:

--- a/models/CustomerCart.js
+++ b/models/CustomerCart.js
@@ -169,6 +169,22 @@ const billSchema = mongoose.Schema(
       type: Number,
       default: null,
     },
+    taxComponents: {
+      type: [
+        {
+          taxName: { type: String, required: true },
+          taxRate: { type: Number, required: true },
+          taxType: {
+            type: String,
+            enum: ["Fixed-amount", "Percentage"],
+            required: true,
+          },
+          amount: { type: Number, required: true },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
   },
   {
     _id: false,

--- a/models/Order.js
+++ b/models/Order.js
@@ -71,6 +71,22 @@ const billSchema = mongoose.Schema(
     promoCodeUsed: { type: String, default: null },
     promoCodeDiscount: { type: Number, default: null },
     returnCharge: { type: Number, default: null },
+    taxComponents: {
+      type: [
+        {
+          taxName: { type: String, required: true },
+          taxRate: { type: Number, required: true },
+          taxType: {
+            type: String,
+            enum: ["Fixed-amount", "Percentage"],
+            required: true,
+          },
+          amount: { type: Number, required: true },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
   },
   { _id: false }
 );

--- a/models/PickAndCustomCart.js
+++ b/models/PickAndCustomCart.js
@@ -69,6 +69,22 @@ const billSchema = mongoose.Schema(
     taxAmount: { type: Number, default: null },
     promoCodeUsed: { type: String, default: null },
     promoCodeDiscount: { type: Number, default: null },
+    taxComponents: {
+      type: [
+        {
+          taxName: { type: String, required: true },
+          taxRate: { type: Number, required: true },
+          taxType: {
+            type: String,
+            enum: ["Fixed-amount", "Percentage"],
+            required: true,
+          },
+          amount: { type: Number, required: true },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
   },
   { _id: false }
 );

--- a/models/ScheduledOrder.js
+++ b/models/ScheduledOrder.js
@@ -43,6 +43,22 @@ const billSchema = mongoose.Schema(
       type: Number,
       default: 0,
     },
+    taxComponents: {
+      type: [
+        {
+          taxName: { type: String, required: true },
+          taxRate: { type: Number, required: true },
+          taxType: {
+            type: String,
+            enum: ["Fixed-amount", "Percentage"],
+            required: true,
+          },
+          amount: { type: Number, required: true },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
     discountedAmount: {
       type: Number,
       default: null,

--- a/models/TemporaryOrder.js
+++ b/models/TemporaryOrder.js
@@ -100,6 +100,22 @@ const billSchema = mongoose.Schema(
     taxAmount: { type: Number, default: null },
     promoCodeUsed: { type: String, default: null },
     promoCodeDiscount: { type: Number, default: null },
+    taxComponents: {
+      type: [
+        {
+          taxName: { type: String, required: true },
+          taxRate: { type: Number, required: true },
+          taxType: {
+            type: String,
+            enum: ["Fixed-amount", "Percentage"],
+            required: true,
+          },
+          amount: { type: Number, required: true },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
   },
   { _id: false }
 );

--- a/utils/createOrderHelpers.js
+++ b/utils/createOrderHelpers.js
@@ -807,6 +807,7 @@ const calculateDeliveryChargesHelper = async ({
   let surgeCharges = null;
   let deliveryChargeForScheduledOrder = null;
   let taxAmount = null;
+  let taxComponents = [];
   let returnCharge = null;
 
   const itemTotal = ["Take Away", "Home Delivery"].includes(deliveryMode)
@@ -903,12 +904,15 @@ const calculateDeliveryChargesHelper = async ({
     }
 
     console.log("🧾 Calculating Tax...");
-    taxAmount = await getTaxAmount(
+    const taxResult = await getTaxAmount(
       businessCategoryId,
       merchant.merchantDetail.geofenceId,
       itemTotal,
       deliveryChargeForScheduledOrder || oneTimeDeliveryCharge
     );
+    const { taxComponents: homeDeliveryTaxComponents, totalTax: homeDeliveryTotalTax } = taxResult;
+    taxAmount = homeDeliveryTotalTax;
+    taxComponents = homeDeliveryTaxComponents;
 
     console.log("💸 Tax Amount:", taxAmount);
   }
@@ -1005,8 +1009,15 @@ const calculateDeliveryChargesHelper = async ({
     if (taxFound) {
       const calculatedTax = (charge * taxFound.tax) / 100;
       taxAmount = parseFloat(calculatedTax.toFixed(2));
-
+      taxComponents = [{
+        taxName: taxFound.taxName,
+        taxRate: taxFound.tax,
+        taxType: taxFound.taxType,
+        amount: taxAmount,
+      }];
       console.log("💸 Tax Amount:", taxAmount);
+    } else {
+      taxComponents = [];
     }
   }
 
@@ -1025,6 +1036,12 @@ const calculateDeliveryChargesHelper = async ({
       if (taxFound) {
         const calculatedTax = (itemTotal * taxFound.tax) / 100;
         taxAmount = parseFloat(calculatedTax.toFixed(2));
+        taxComponents = [{
+          taxName: taxFound.taxName,
+          taxRate: taxFound.tax,
+          taxType: taxFound.taxType,
+          amount: taxAmount,
+        }];
         console.log("💸 Take Away Tax Amount:", taxAmount);
       }
     }
@@ -1046,6 +1063,7 @@ const calculateDeliveryChargesHelper = async ({
     surgeCharges,
     deliveryChargeForScheduledOrder,
     taxAmount,
+    taxComponents,
     itemTotal,
     returnCharge,
   };
@@ -1114,7 +1132,8 @@ const calculateBill = (
   merchantDiscountAmount,
   taxAmount,
   addedTip = 0,
-  returnCharge = 0
+  returnCharge = 0,
+  taxComponents = []
 ) => {
   // Calculate total discount amount once
   const totalDiscountAmount =
@@ -1149,6 +1168,7 @@ const calculateBill = (
     addedTip,
     subTotal: parseFloat(subTotal).toFixed(2),
     taxAmount: parseFloat(taxAmount).toFixed(2),
+    taxComponents,
     surgePrice: surgeCharges || null,
     discountedAmount: totalDiscountAmount > 0 ? totalDiscountAmount : null,
     originalGrandTotal: Math.round(grandTotal),
@@ -1475,6 +1495,7 @@ const calculateDeliveryChargeHelperForAdmin = async (
       const takeAwayItemTotal = calculateItemTotal(items, scheduledDetails?.numOfDays);
 
       let takeAwayTaxAmount = 0;
+      let takeAwayTaxComponents = [];
 
       const appCustomization = await CustomerAppCustomization.findOne({}).select(
         "takeAwayOrderCustomization"
@@ -1487,6 +1508,12 @@ const calculateDeliveryChargeHelperForAdmin = async (
           takeAwayTaxAmount = parseFloat(
             ((takeAwayItemTotal * taxFound.tax) / 100).toFixed(2)
           );
+          takeAwayTaxComponents = [{
+            taxName: taxFound.taxName,
+            taxRate: taxFound.tax,
+            taxType: taxFound.taxType,
+            amount: takeAwayTaxAmount,
+          }];
         }
       }
 
@@ -1495,6 +1522,7 @@ const calculateDeliveryChargeHelperForAdmin = async (
         surgeCharges: 0,
         deliveryChargeForScheduledOrder: 0,
         taxAmount: takeAwayTaxAmount,
+        taxComponents: takeAwayTaxComponents,
         itemTotal: takeAwayItemTotal,
       };
     }
@@ -1667,9 +1695,16 @@ const pickAndDropCharges = async (
   const charge = deliveryChargeForScheduledOrder ?? oneTimeDeliveryCharge;
 
   let taxAmount = 0;
+  let taxComponents = [];
   if (taxFound) {
     const calculatedTax = (charge * taxFound.tax) / 100;
     taxAmount = parseFloat(calculatedTax.toFixed(2));
+    taxComponents = [{
+      taxName: taxFound.taxName,
+      taxRate: taxFound.tax,
+      taxType: taxFound.taxType,
+      amount: taxAmount,
+    }];
   }
 
   return {
@@ -1677,6 +1712,7 @@ const pickAndDropCharges = async (
     surgeCharges: surgeCharges || null,
     deliveryChargeForScheduledOrder: deliveryChargeForScheduledOrder || null,
     taxAmount,
+    taxComponents,
     itemTotal: null,
     returnCharge,
   };
@@ -1763,9 +1799,16 @@ const customOrderCharges = async (
   const charge = deliveryChargeForScheduledOrder || oneTimeDeliveryCharge;
 
   let taxAmount = 0;
+  let taxComponents = [];
   if (taxFound) {
     const calculatedTax = (charge * taxFound.tax) / 100;
     taxAmount = parseFloat(calculatedTax.toFixed(2));
+    taxComponents = [{
+      taxName: taxFound.taxName,
+      taxRate: taxFound.tax,
+      taxType: taxFound.taxType,
+      amount: taxAmount,
+    }];
   }
 
   return {
@@ -1775,6 +1818,7 @@ const customOrderCharges = async (
       ? deliveryChargeForScheduledOrder
       : 0,
     taxAmount,
+    taxComponents,
     itemTotal: 0,
   };
 };

--- a/utils/customerAppHelpers.js
+++ b/utils/customerAppHelpers.js
@@ -269,16 +269,32 @@ const getTaxAmount = async (
       assignToBusinessCategory: businessCategoryId,
       geofences: { $in: [geofenceId] },
       status: true,
+    }).lean();
+
+    if (!taxesFound.length) {
+      return { taxComponents: [], totalTax: 0 };
+    }
+
+    const taxComponents = taxesFound.map((t) => {
+      let amount = 0;
+      if (t.taxType === "Fixed-amount") {
+        amount = t.tax;
+      } else {
+        amount = (parseFloat(itemTotal) * t.tax) / 100;
+      }
+      return {
+        taxName: t.taxName,
+        taxRate: t.tax,
+        taxType: t.taxType,
+        amount: parseFloat(amount.toFixed(2)),
+      };
     });
 
-    if (!taxesFound.length) throw new Error("Tax not found");
+    const totalTax = parseFloat(
+      taxComponents.reduce((sum, c) => sum + c.amount, 0).toFixed(2)
+    );
 
-    const taxAmount = taxesFound.reduce((sum, t) => {
-      if (t.taxType === "Fixed-amount") return sum + t.tax;
-      return sum + (parseFloat(itemTotal) * t.tax) / 100;
-    }, 0);
-
-    return parseFloat(taxAmount.toFixed(2));
+    return { taxComponents, totalTax };
   } catch (err) {
     throw new Error(err.message);
   }


### PR DESCRIPTION
# Geofence Bypass Fix — Root Cause, Changes & Front-End Integration

## The Problem

Customers could place orders from **any address**, including addresses hundreds of kilometres outside any defined service area. An admin could define geofences in the dashboard, but they were never enforced at the point of order placement.

---

## Root Cause

Three separate failures allowed out-of-geofence orders through:

### 1. Registration — «soft» null, not a hard block

In `customerController.js` (`registerAndLoginController`), the `geoLocation()` utility was called during registration:

```js
// Line 115 — geoLocation IS called
const geofence = await geoLocation(latitude, longitude, next);

// Line 135 — but null is tolerated:
geofenceId: geofence?._id ? geofence?._id : null,
```

A user outside all geofences registers successfully with `geofenceId: null`. No error is returned.

### 2. Browse — null means «show everything»

In `universalOrderController.js` (`getAllBusinessCategoryController`), geoLocation is called, but when it returns `null`, the query filter is skipped entirely:

```js
if (geofence) {
  query.geofenceId = { $in: [geofence._id] };
}
// When geofence is null: all merchants are returned.
// The API also sends `outside: true` to the front-end,
// but the front-end is not required to act on it.
```

The app **knows** the user is outside, but the backend lets browsing + browsing through continue normally.

### 3. Order placement — NO geofence check at all (the bug)

In `universalOrderController.js` (`confirmOrderDetailController`), the delivery address coordinates were extracted, distance was computed, pricing was calculated, and the cart was saved — but `geoLocation()` was **never called** on the delivery address coordinates. There was no check at all.

Similarly in `pickAndDropController.js` (`getVehiclePricingDetailsController`), the pricing lookup used the **customer's registration-time geofence** (`customer.customerDetails.geofenceId`), which was often `null` for out-of-service users, causing a «Customer Pricing not found» error instead of a clear «outside service area» message — or, when it happened to be non-null, pricing from the wrong geofence.

---

## What Was Changed

### File 1: `controllers/customer/universalOrderController.js` — Home Delivery gate

**Old code (simplified):**

```js
const { deliveryLocation, ... } = await processHomeDeliveryDetailInApp(...);
// ❌ No geofence validation on the delivery address
const cartItems = cart.items;
```

**New code:**

```js
const { deliveryLocation, ... } = await processHomeDeliveryDetailInApp(...);

// ✅ Validate delivery address against geofences
if (deliveryMode === "Home Delivery") {
  if (!Array.isArray(deliveryLocation) || deliveryLocation.length < 2) {
    return next(appError("Delivery location coordinates are missing", 400));
  }

  const deliveryGeofence = await geoLocation(
    deliveryLocation[0],   // latitude
    deliveryLocation[1],   // longitude
  );

  if (!deliveryGeofence) {
    return next(
      appError(
        "Delivery address is outside our service area. Please choose a different address.",
        400,
      ),
    );
  }
}

const cartItems = cart.items;
```

**When it runs:** Right after `processHomeDeliveryDetailInApp()` returns — at the point when the user types/selects their delivery address and clicks confirm. Before any pricing is committed to the cart.

---

### File 2: `controllers/customer/pickAndDropController.js` — Pick & Drop gate

**Old code:**

```js
const customerPricingArray = await CustomerPricing.find({
  deliveryMode: "Pick and Drop",
  geofenceId: customer.customerDetails.geofenceId,  // ❌ stale/null
  status: true,
  vehicleType: { $in: uniqueVehicleTypes },
});

const customerSurge = await CustomerSurge.findOne({
  geofenceId: customer.customerDetails.geofenceId,  // ❌ stale/null
  status: true,
});
```

**New code:**

```js
// ✅ Resolve geofence from the FIRST pickup address coordinates
const firstPickup = cartFound.pickups?.[0];
if (!firstPickup?.location || !Array.isArray(firstPickup.location) || firstPickup.location.length < 2) {
  return next(appError("Pickup location coordinates are missing or invalid", 400));
}

const [pickupLat, pickupLng] = firstPickup.location;
const resolvedGeofence = await geoLocation(pickupLat, pickupLng);

if (!resolvedGeofence) {
  return next(
    appError(
      "Pickup location is outside our service area. Please choose a different pickup address.",
      400,
    ),
  );
}

// ✅ Use the resolved geofence for pricing, not the stale registration value
const customerPricingArray = await CustomerPricing.find({
  deliveryMode: "Pick and Drop",
  geofenceId: resolvedGeofence._id,
  status: true,
  vehicleType: { $in: uniqueVehicleTypes },
});

const customerSurge = await CustomerSurge.findOne({
  geofenceId: resolvedGeofence._id,
  status: true,
});
```

---

## Architecture of the Geofence Check

### The Utility: `utils/getGeoLocation.js`

This function already existed and needed no changes:

```
geoLocation(latitude, longitude)
  → takes [lat, lng] as separate args
  → constructs a GeoJSON point [lng, lat] (Turf.js convention)
  → loops all active geofences, swaps their stored polygon coords [lat,lng] → [lng,lat]
  → calls @turf/turf `booleanPointInPolygon()`
  → returns the Geofence document if inside, or `null` if outside
```

### Data Flow Diagram

```
User types delivery address
         │
         ▼
processHomeDeliveryDetailInApp()
  → gets coordinates from saved address OR new address
  → returns deliveryLocation = [latitude, longitude]
         │
         ▼
  ┌─ geoLocation(lat, lng) ──────────────────┐
  │  inside any polygon?  →  continue         │
  │  outside all polygons →  400 error + msg  │
  └───────────────────────────────────────────┘
         │
         ▼
Calculate pricing, save to cart
```

---

## Front-End Developer Instructions (Platform-Agnostic)

No front-end changes are required for the fix to work — the backend now returns a `400` error when the delivery address is outside service areas. The app will already see this as a failed API call. However, for a **good user experience**, implement the following:

### 1. Show a clear error when order placement fails

**Endpoint:** `POST /cart/add-details` (or whatever your app calls the confirm-order-detail route)

**New behaviour:** When the delivery/pickup address coordinates are outside all defined geofences, the API returns:

```json
{
  "success": false,
  "message": "Delivery address is outside our service area. Please choose a different address."
}
```

**What to do:** Catch the 400 error and show this message as an inline error above the address form — do not navigate away or reset the entire cart.

### 2. (Optional but recommended) Prevent wasted effort — check the address before the user fills out everything

The backend also has a read-only endpoint that lets you probe an address before the user goes through the full order flow:

**Endpoint:** `POST /verify-customer-address-location`
**Body:**
```json
{
  "customerId": "<customer_id>",
  "latitude": <address_latitude>,
  "longitude": <address_longitude>
}
```

**Response when outside:**
```json
{
  "success": false,
  "insideGeofence": false
}
```

**Suggested UX flow:**
1. User types/selects a delivery address.
2. Address gets geocoded to coordinates.
3. Call `/verify-customer-address-location` with those coords.
4. If `success: false`, disable the «Proceed» button and show a message: *"We don't deliver to this address yet. Try a different address."*
5. If `success: true`, let the user continue normally.

This endpoint does not create or modify any order data — it's safe to call as many times as you want.

### 3. (Optional) Inform the user earlier — during browsing

The backend's browse endpoint already returns an `outside` flag:

**Endpoint:** `GET /getAllBusinessCategory`
**Body:**
```json
{
  "latitude": <current_lat>,
  "longitude": <current_lng>
}
```

**Response includes:**
```json
{
  "outside": true,
  "data": [...]
}
```

Apps that want to be extra helpful can show a banner at the top of the home screen: *"You appear to be outside our delivery area. You can still browse, but you'll need a delivery address within our service area to place an order."*

### 4. What NOT to do

- ❌ Do NOT show a generic error toast that says "Something went wrong" — the user needs to know it's the **address**, not the payment or the network.
- ❌ Do NOT silently reset the form or navigate to the home screen — let the user correct their address and retry.
- ❌ Do NOT block the user from leaving the page — they might want to pick a different address and continue.

### 5. Pick & Drop (special case)

For Pick & Drop orders, the geofence check is based on the **first pickup address** (not the drops). If your app has a multi-step Pick & Drop flow where the user enters pickups and drops separately, make sure the pricing/confirmation step is not reachable until at least one pickup address has been saved.

---

## Summary

| What | Old behaviour | New behaviour |
|---|---|---|
| Registration | `geofenceId` set to `null` outside area | **Unchanged** (user can still browse) |
| Browse | All merchants shown, `outside: true` flag sent | **Unchanged** (user can still browse) |
| **Order placement** | **No check — order went through** | **400 error if address is outside** |
| Pick & Drop pricing | Used stale registration `geofenceId` (often null) | **Resolved from pickup address coordinates** |
| Error message | None or vague «not found» | Clear instruction to pick a different address |

---

## Files Modified

| File | Change |
|---|---|
| `controllers/customer/universalOrderController.js` | Added `geoLocation()` check after `processHomeDeliveryDetailInApp()` for Home Delivery orders |
| `controllers/customer/pickAndDropController.js` | Added `geoLocation()` import + validation + replaced stale `customer.customerDetails.geofenceId` with live-resolved geofence |

*March 2026 — Famto Backend*
