### PR TITLE
fix/customerSearchInDashboard

### DIFF
--- a/controllers/admin/customer/customerController.js
+++ b/controllers/admin/customer/customerController.js
@@ -91,8 +91,14 @@ const searchCustomerByNameController = async (req, res, next) => {
     // Calculate the number of documents to skip
     const skip = (page - 1) * limit;
 
+    const trimmedQuery = query.trim();
+
     const searchCriteria = {
-      fullName: { $regex: query.trim(), $options: "i" },
+      $or: [
+        { fullName: { $regex: trimmedQuery, $options: "i" } },
+        { phoneNumber: { $regex: trimmedQuery, $options: "i" } },
+        { _id: { $regex: trimmedQuery, $options: "i" } },
+      ],
       "customerDetails.isBlocked": false,
     };
 
@@ -105,7 +111,7 @@ const searchCustomerByNameController = async (req, res, next) => {
       .lean({ virtuals: true });
 
     // Count total documents
-    const totalDocuments = (await Customer.countDocuments(searchCriteria)) || 1;
+    const totalDocuments = await Customer.countDocuments(searchCriteria);
 
     // Calculate averageRating and format registrationDate for each customer
     const formattedCustomers = searchResults.map((customer) => {
@@ -264,6 +270,12 @@ const fetchAllCustomersByAdminController = async (req, res, next) => {
             $options: "i",
           },
         },
+        {
+          _id: {
+            $regex: query.trim(),
+            $options: "i",
+          },
+        },
       ];
     }
 
@@ -315,6 +327,7 @@ const searchCustomerByNameForOrderController = async (req, res, next) => {
       $or: [
         { fullName: { $regex: query.trim(), $options: "i" } },
         { phoneNumber: { $regex: query.trim(), $options: "i" } },
+        { _id: { $regex: query.trim(), $options: "i" } },
       ],
       "customerDetails.isBlocked": false,
     };
@@ -1056,7 +1069,11 @@ const searchCustomerByNameForMerchantController = async (req, res, next) => {
 
     const searchCriteria = {
       _id: { $in: uniqueCustomerIds },
-      fullName: { $regex: query.trim(), $options: "i" },
+      $or: [
+        { fullName: { $regex: query.trim(), $options: "i" } },
+        { phoneNumber: { $regex: query.trim(), $options: "i" } },
+        { _id: { $regex: query.trim(), $options: "i" } },
+      ],
     };
 
     // Find customers by name who belong to this merchant (parallel count)
@@ -1226,11 +1243,27 @@ const fetchCustomersOfMerchantController = async (req, res, next) => {
         mongoose.Types.ObjectId.createFromHexString(geofence.trim());
     }
 
-    if (query && query.trim !== "") {
-      matchCriteria.fullName = {
-        $regex: query.trim(),
-        $options: "i",
-      };
+    if (query && query.trim() !== "") {
+      matchCriteria.$or = [
+        {
+          fullName: {
+            $regex: query.trim(),
+            $options: "i",
+          },
+        },
+        {
+          phoneNumber: {
+            $regex: query.trim(),
+            $options: "i",
+          },
+        },
+        {
+          _id: {
+            $regex: query.trim(),
+            $options: "i",
+          },
+        },
+      ];
     }
 
     const [result, totalCount] = await Promise.all([
@@ -1295,7 +1328,11 @@ const searchCustomerByNameForMerchantToOrderController = async (
     // Find customers by name who belong to this merchant
     const searchResults = await Customer.find({
       _id: { $in: uniqueCustomerIds },
-      fullName: { $regex: query.trim(), $options: "i" },
+      $or: [
+        { fullName: { $regex: query.trim(), $options: "i" } },
+        { phoneNumber: { $regex: query.trim(), $options: "i" } },
+        { _id: { $regex: query.trim(), $options: "i" } },
+      ],
     })
       .select(
         "fullName email phoneNumber lastPlatformUsed createdAt customerDetails"


### PR DESCRIPTION
# Customer Search — ID Search Fix

**Files changed:** Only `Famto_Backend_Native/controllers/admin/customer/customerController.js`

**Frontend changes:** None. All 6 endpoints keep the same URL, query parameter (`?query=...`), and response shape.

---

## The Problem

Typing a customer ID like `C2507123` into any admin/merchant customer search box returned **zero results**. Name and phone searches worked fine.

**Root cause:** All 6 search/fetch controllers only queried the `fullName` field. `_id` was never included, so MongoDB searched for a customer whose **name** matched the ID — which never matched.

### Why `_id` is searchable as a string

The Customer model's `_id` is typed as `String` (not `ObjectId`), auto-generated as `C` + YY + MM + counter:

```js
// models/Customer.js
_id: { type: String },
// pre("save") generates: _id = "C2507123"
```

Since it's a plain string, `$regex` works on it directly — no ObjectId conversion needed.

---

## Change 1 — `searchCustomerByNameController` (`GET /admin/customer/search`)

**Old:**
```js
const searchCriteria = {
  fullName: { $regex: query.trim(), $options: "i" },
  "customerDetails.isBlocked": false,
};
const totalDocuments = (await Customer.countDocuments(searchCriteria)) || 1;
```

**New:**
```js
const trimmedQuery = query.trim();
const searchCriteria = {
  $or: [
    { fullName: { $regex: trimmedQuery, $options: "i" } },
    { phoneNumber: { $regex: trimmedQuery, $options: "i" } },
    { _id: { $regex: trimmedQuery, $options: "i" } },
  ],
  "customerDetails.isBlocked": false,
};
const totalDocuments = await Customer.countDocuments(searchCriteria);
```

**What changed:**
- Bare `fullName` regex → `$or` across `fullName + phoneNumber + _id`
- Removed `|| 1` guard (was hiding empty results)
- `query.trim()` extracted once into `trimmedQuery`

---

## Change 2 — `fetchAllCustomersByAdminController` (`GET /admin/customer/fetch-customer`)

**Old:**
```js
if (query && query.trim() !== "") {
  matchCriteria.$or = [
    { fullName: { $regex: query.trim(), $options: "i" } },
    { phoneNumber: { $regex: query.trim(), $options: "i" } },
  ];
}
```

**New:** Added `_id` as a third `$or` option.

---

## Change 3 — `searchCustomerByNameForOrderController` (`GET /admin/customer/search-for-order`)

**Old:** Had `$or` with `fullName + phoneNumber` only. **New:** Added `_id`.

---

## Change 4 — `searchCustomerByNameForMerchantController` (`GET /admin/customer/search-customer-of-merchant`)

**Old:**
```js
const searchCriteria = {
  _id: { $in: uniqueCustomerIds },
  fullName: { $regex: query.trim(), $options: "i" },
};
```

**New:** Bare `fullName` → `$or` across `fullName + phoneNumber + _id`.

---

## Change 5 — `fetchCustomersOfMerchantController` (`GET /admin/customer/fetch-customer-of-merchant`)

**Old:**
```js
if (query && query.trim !== "") {     // ← BUG: query.trim is always truthy
  matchCriteria.fullName = {
    $regex: query.trim(),
    $options: "i",
  };
}
```

**New:**
```js
if (query && query.trim() !== "") {   // ← Fixed: added ()
  matchCriteria.$or = [
    { fullName: { $regex: query.trim(), $options: "i" } },
    { phoneNumber: { $regex: query.trim(), $options: "i" } },
    { _id: { $regex: query.trim(), $options: "i" } },
  ];
}
```

**What changed:**
- `query.trim !== ""` → `query.trim() !== ""` (missing parentheses — was comparing a function reference to a string, always true)
- Bare `fullName` → `$or` across `fullName + phoneNumber + _id`

---

## Change 6 — `searchCustomerByNameForMerchantToOrderController` (`GET /admin/customer/search-customer-of-merchant-for-order`)

Same as Change 4: bare `fullName` → `$or` across `fullName + phoneNumber + _id`.

---

## Frontend — No Changes

Every frontend search box (admin dashboard, merchant panel, order creation) already sends `?query=...` to these endpoints and expects the same response format. Nothing changed on the frontend side.

| Frontend feature | Backend endpoint |
|---|---|
| Admin customer search box | `GET /admin/customer/search` |
| Admin customer filters sidebar | `GET /admin/customer/fetch-customer` |
| Admin order creation — customer picker | `GET /admin/customer/search-for-order` |
| Merchant customer list | `GET /admin/customer/fetch-customer-of-merchant` |
| Merchant customer search | `GET /admin/customer/search-customer-of-merchant` |
| Merchant order creation — customer picker | `GET /admin/customer/search-customer-of-merchant-for-order` |