### PR TITLE
Migration/map abstraction

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Famto Backend — Architecture
 
 > **Role:** REST + Socket.IO API server serving all clients (Flutter mobile app, React web ordering, React admin dashboard, WhatsApp bots).
-> **Stack:** Node 20 · Express 4.21 · MongoDB (Mongoose 8.7) · Socket.IO 4.7 · JWT · Razorpay (India)
+> **Stack:** Node 20 · Express 4.21 · MongoDB (Mongoose 8.7) · Socket.IO 4.7 · Redis 7.x · BullMQ · JWT · Razorpay (India)
 
 ---
 
@@ -42,10 +42,15 @@ npm start
 │         │                          └──────────────────────┘  │
 │         │                          ┌──────────────────────┐  │
 │         ├──────────────────────────►  Firebase (external) │  │
-│                                   └──────────────────────┘  │
+│         │                          └──────────────────────┘  │
+│         │                          ┌──────────────────────┐  │
+│         └──────────────────────────►  Redis (internal)    │  │
+│                                    │  Socket.IO adapter   │  │
+│                                    │  BullMQ queues       │  │
+│                                    │  Driver Geo storage  │  │
+│                                    └──────────────────────┘  │
 └──────────────────────────────────────────────────────────────┘
 ```
-
 ---
 
 ## Code Layout
@@ -118,7 +123,7 @@ index.js                  ← Entry point: routes + 5 cron jobs (711 lines)
 | Templates | EJS | 3.1 |
 | PDF generation | puppeteer | 23.5 |
 | Image processing | sharp | 0.33 |
-| Caching | node-cache | 5.1 |
+| Caching | Redis + node-cache | 7.x |
 | Email | nodemailer | 6.9 |
 | SMS/WhatsApp | axios | external API calls |
 | Validation | express-validator | 7.2 |
@@ -140,18 +145,18 @@ index.js                  ← Entry point: routes + 5 cron jobs (711 lines)
 
 ## Architecture Decisions
 
-### ADR-001: No Redis at Current Scale
+### ADR-001: Redis — Adopted (was "No Redis")
 
-**Decision:** Do not deploy Redis. All proposed use cases are served by in-process mechanisms:
-- `node-cache` for hot data (faster than Redis at 0ms vs 0.3ms TCP round-trip)
-- MongoDB TTL indexes for token blacklisting
-- MemoryStore for rate limiting
+> **Status:** SUPERSEDED by ADR-003, ADR-004, and ADR-005 below.
+> **Original reasoning:** In-process mechanisms (node-cache, MemoryStore, TTL indexes) were sufficient for single-process scale.
+> **Trigger for reversal:** Need for horizontal scaling of Socket.IO, persistent background jobs, and cross-node driver location sharing.
 
-**Revisit when:**
-1. 2+ Node processes running (need Redis for socket.io adapter)
-2. Single query exceeds 50ms due to collection size
-3. Throughput exceeds ~500 RPS on read-heavy endpoints
-4. Cross-service pub/sub needed (microservices)
+**Decision:** Introduce Redis as a first-class infrastructural dependency. Redis powers:
+- **Socket.IO adapter** (`@socket.io/redis-adapter`) — enables multiple Node processes to share real-time state
+- **BullMQ** — replaces in-process `node-cron` polling with persistent, retryable job queues
+- **Redis Geo** (`GEOADD` / `GEORADIUS`) — replaces in-memory `userSocketMap` for driver location storage
+
+See ADR-003, ADR-004, ADR-005 for details per use case.
 
 ### ADR-002: Performance Priority Framework
 
@@ -165,7 +170,82 @@ All fixes are **free** (zero new infrastructure). Execute in order:
 | 4 | Strip `console.log` from production code paths | Unblocks event loop (Node stdout is synchronous) |
 | 5 | In-process rate limiting via express-rate-limit + MemoryStore | Abuse prevention |
 | 6 | Token blacklist via MongoDB TTL index | Server-side JWT invalidation |
-| 7 | *Re-evaluate Redis* | Marginal after above |
+| 7 | *(Superseded — Redis adopted per ADR-001)* | — |
+
+### ADR-003: Socket.IO Redis Adapter for Horizontal Scaling
+
+**Decision:** Add `@socket.io/redis-adapter` and `ioredis` to the project. Attach the adapter to the existing Socket.IO server instance (socket/socket.js).
+
+**Why:**
+- `userSocketMap` lives in a single Node process's memory. Deploy/restart drops all connected sockets and their in-memory state.
+- Without a shared adapter, only one Node process can serve WebSocket connections — you cannot horizontally scale the real-time layer.
+- A Redis adapter lets Socket.IO broadcast events (`io.emit`) across all connected processes. Any process can emit to any socket, regardless of which process owns that socket.
+
+**Revisit when:** Never (adapter is trivially cheap at ~$15/mo Redis instance and adds zero latency overhead vs. in-process for a single process).
+
+**Trade-off:**
+- New infrastructure dependency (Redis). Mitigation: Redis has near-zero downtime and the adapter is a well-maintained first-party Socket.IO package.
+- Adds ~0.3ms TCP round-trip per event when a single process emits to a socket on another process. Events emitted to sockets on the same process stay local (no Redis hop).
+
+### ADR-004: BullMQ for Background Jobs
+
+**Decision:** Replace in-process `node-cron` polling with BullMQ (backed by the same Redis instance from ADR-003).
+
+**Current problem:**
+- All 8 cron schedules run inside the single Node process.
+- The every-5-second `TemporaryOrder` poller (`*/5 * * * * *` in index.js) is lossy: if the process crashes between polls, unprocessed orders disappear.
+- No retry mechanism — a job that fails mid-way is gone forever.
+- If we run 2+ Node processes in the future, every process runs every cron → duplicate execution.
+
+**Why BullMQ:**
+- **Persistence:** Jobs survive process restarts and server crashes.
+- **Delayed jobs:** Order timeout, auto-cancellation, and scheduled pickups expressed as delayed jobs instead of polling.
+- **Workers:** Job processing runs in separate worker processes that can be scaled independently.
+- **Deduplication:** BullMQ's job dedup (`jobId` option) prevents duplicate execution when multiple processes enqueue the same logical job.
+- **Retries:** Built-in backoff and max attempts per job.
+
+**What moves to BullMQ:**
+
+| Current cron | Frequency | BullMQ pattern |
+|-------------|-----------|----------------|
+| TemporaryOrder processing | `*/5 * * * * *` (every 5s) | Queue worker + delayed job per order |
+| Order auto-cancellation | `* * * * *` (every min) | Delayed job with TTL check |
+| Automated status offlines | `0 6,12,18,0 * * *` (4x daily) | Cron-like repeatable job |
+| Analytics rollup | `30 18 * * *` (daily) | Repeatable job |
+| Invoice/statement generation | `* * * * *` (every min) | Queue per merchant |
+| Other cron-based checks | various | Queue per domain |
+
+**Trade-off:**
+- Redis is a hard dependency for job processing (same instance as ADR-003, no extra cost).
+- Worker processes add process-management complexity vs. simple `node-cron` inline schedules. Mitigation: start with the worker running inside the main process (BullMQ supports this), extract to separate workers when load demands.
+
+### ADR-005: Driver Location Storage in Redis Geo
+
+**Decision:** Move active driver locations from the in-memory `userSocketMap` object into Redis Geo structures.
+
+**Current implementation (socket/socket.js):**
+- `locationUpdated` event writes `[latitude, longitude]` to `userSocketMap[userId].location` (a plain JS object in-process).
+- Customers poll via `agentLocationUpdateForUser` which reads from the same in-memory map.
+- **Lost on every restart.** No historical location data. Only queryable from the one Node process that owns the map.
+
+**Target architecture:**
+| Operation | Redis Command | When |
+|-----------|--------------|------|
+| Store driver position | `GEOADD drivers:live <lng> <lat> <driverId>` | On every `locationUpdated` socket event |
+| Query driver near point | `GEORADIUS drivers:live <lng> <lat> <radius> km` | Customer requests `agentLocationUpdateForUser` |
+| Get single driver position | `GEOPOS drivers:live <driverId>` | Admin panel / order detail |
+| Remove on disconnect | `ZREM drivers:live <driverId>` | On socket `disconnect` event |
+| TTL cleanup | `EXPIRE drivers:live <ttl>` + periodic GEOSEARCHSTORE | Stale positions expire automatically |
+
+**Why Redis Geo:**
+- Survives restarts (Redis persistence/RDB snapshots).
+- Queryable from any Node process (no single-process bottleneck).
+- Built-in geospatial query (`GEORADIUS`) replaces manual distance-filtering in application code.
+- Single-digit microsecond latency per operation.
+
+**Trade-off:**
+- Adds ~0.3ms TCP round-trip per location update. Mitigation: batch writes (e.g., update Redis every 5s, not on every client message) or use Redis pipelining.
+- Existing `userSocketMap` also holds WebSocket socket IDs and FCM tokens — those stay in-process and cluster-local (they're ephemeral and tied to the specific Node process anyway). Redis Geo only replaces the **location** portion.
 
 ### Custom String IDs
 
@@ -219,6 +299,7 @@ See `MAP_SERVICE_STRATEGY.md` at project root for full evaluation.
 | Service | Port | Environment |
 |---------|------|-------------|
 | Express API | 8080 | Container (EXPOSE) |
+| Redis | 6379 | Container or managed (same VPS) |
 | MongoDB | external | Atlas or VPS-hosted |
 | Firebase | external | Google |
 
@@ -229,9 +310,10 @@ See `MAP_SERVICE_STRATEGY.md` at project root for full evaluation.
 - **Runtime:** Docker container on own VPS (Alpine, Node 20)
 - **Base image:** `node:20-alpine`
 - **Port:** 8080
-- **Cron jobs:** 5 scheduled in `index.js` (auto-cancellation, bonus processing, etc.)
+- **Cron jobs:** 5 scheduled in `index.js` — targeted for migration to BullMQ (see ADR-004)
 - **Start command:** `node index.js --host 0.0.0.0`
-- **No CI/CD** — manual `docker build` + `docker-compose pull/up` on VPS
+- **Background workers:** BullMQ workers process job queues (persistent, retryable)
+- **No CI/CD** — manual `docker build` + deploy via SSH on VPS
 
 ---
 

--- a/controllers/admin/deliveryManagement/taskController.js
+++ b/controllers/admin/deliveryManagement/taskController.js
@@ -18,9 +18,7 @@ const {
 } = require("../../../socket/socket");
 
 const appError = require("../../../utils/appError");
-const {
-  getDistanceFromPickupToDelivery,
-} = require("../../../utils/customerAppHelpers");
+const mapService = require("../../../services/MapService");
 const { formatDate, formatTime } = require("../../../utils/formatters");
 const BatchOrder = require("../../../models/BatchOrder");
 const {
@@ -257,7 +255,7 @@ const getAgentsAccordingToGeofenceController = async (req, res, next) => {
         // Only calculate distance for Free/Busy agents; Inactive agents default to 0
         if (agent.status === "Free" || agent.status === "Busy") {
           if (deliveryMode === "Pick and Drop" && deliveryLocation?.length === 2) {
-            const { distanceInKM } = await getDistanceFromPickupToDelivery(
+            const { distanceInKM } = await mapService.getDistance(
               agentLocation,
               deliveryLocation
             );
@@ -266,7 +264,7 @@ const getAgentsAccordingToGeofenceController = async (req, res, next) => {
             deliveryMode !== "Custom Order" &&
             merchantLocation?.length === 2
           ) {
-            const { distanceInKM } = await getDistanceFromPickupToDelivery(
+            const { distanceInKM } = await mapService.getDistance(
               agentLocation,
               merchantLocation
             );
@@ -659,7 +657,7 @@ const testSocket = async (req, res, next) => {
     let distanceCoveredByAgent = 0;
 
     if (orderFound?.deliveryMode === "Custom Order") {
-      const { distanceInKM } = await getDistanceFromPickupToDelivery(
+      const { distanceInKM } = await mapService.getDistance(
         location,
         delivery.location
       );

--- a/controllers/admin/map/mapController.js
+++ b/controllers/admin/map/mapController.js
@@ -1,4 +1,4 @@
-const axios = require("axios");
+const mapService = require("../../../services/MapService");
 
 const getPolylineController = async (req, res) => {
   const { path } = req.body;
@@ -9,69 +9,28 @@ const getPolylineController = async (req, res) => {
       .json({ error: "At least two valid coordinates required" });
   }
 
-  // -----------------------------
-  // SAFE NORMALIZER
-  // -----------------------------
-  const normalizeLatLng = (loc) => {
-  if (!loc) return null;
-
-  if (typeof loc.toObject === "function") {
-    loc = loc.toObject();
+  // Normalize each waypoint to [lat, lng] via MapService (handles all
+  // input formats — array, object, mongoose doc, [lng,lat] swap, etc.)
+  const normalizedPath = [];
+  for (const point of path) {
+    const norm = mapService.normalize(point);
+    if (!norm) {
+      return res.status(400).json({
+        error: `Invalid coordinate in path: ${JSON.stringify(point)}`,
+      });
+    }
+    normalizedPath.push(norm);
   }
-
-  if (!Array.isArray(loc) || loc.length !== 2) return null;
-
-  let a = Number(loc[0]);
-  let b = Number(loc[1]);
-
-  if (Number.isNaN(a) || Number.isNaN(b)) return null;
-
-  // Standard out-of-range swap (handles |lng| > 90 cases)
-  if (Math.abs(a) > 90 && Math.abs(b) <= 90) {
-    return [b, a];
-  }
-
-  // India-specific heuristic:
-  // lng is ~68–98, lat is ~6–38
-  // If a looks like an Indian longitude and b looks like a latitude → swap
-  const looksLikeIndianLng = (v) => v >= 60 && v <= 100;
-  const looksLikeIndianLat = (v) => v >= 5 && v <= 40;
-
-  if (looksLikeIndianLng(a) && looksLikeIndianLat(b)) {
-    return [b, a]; // swap [lng, lat] → [lat, lng]
-  }
-
-  return [a, b];
-};
-
-  // -----------------------------
-  // BUILD MAPMYINDIA STRING (lng,lat)
-  // -----------------------------
-  const coordinateString = path
-    .map((point) => {
-      const normalized = normalizeLatLng(point);
-
-      if (!normalized) return null;
-
-      const [lat, lng] = normalized;
-
-      return `${lng},${lat}`; // REQUIRED FORMAT
-    })
-    .filter(Boolean)
-    .join(";");
-
-  console.log("COORDINATE STRING:", coordinateString);
-
-  const url = `https://apis.mapmyindia.com/advancedmaps/v1/${process.env.MapMyIndiaAPIKey}/route_adv/biking/${coordinateString}?geometries=geojson`;
 
   try {
-    const response = await axios.get(url);
-    return res.json(response.data);
+    // MapService delegates to the active provider (today: Mappls).
+    // The provider handles the lng,lat format that the API requires.
+    const data = await mapService.getRoutePolyline(normalizedPath, "biking");
+    return res.json(data);
   } catch (err) {
     console.error("Polyline error:", err.response?.data || err.message);
-
     return res.status(500).json({
-      error: "Failed to fetch polyline path from MapMyIndia API",
+      error: "Failed to fetch polyline path from map service",
     });
   }
 };

--- a/controllers/admin/merchant/merchantController.js
+++ b/controllers/admin/merchant/merchantController.js
@@ -1,3 +1,4 @@
+const mapService = require("../../../services/MapService");
 const { validationResult } = require("express-validator");
 const bcrypt = require("bcryptjs");
 const mongoose = require("mongoose");
@@ -522,16 +523,18 @@ const updateMerchantDetailsByMerchantController = async (req, res, next) => {
       !arraysAreEqual(newLocation, existingCoords)
     ) {
       const [lng, lat] = newLocation;
-      const url = `https://apis.mapmyindia.com/advancedmaps/v1/9a632cda78b871b3a6eb69bddc470fef/still_image?center=${lng},${lat}&size=400x500&markers=${lng},${lat}&zoom=15`;
 
       try {
-        const response = await axios.get(url, { responseType: "arraybuffer" });
+        // Use MapService for static map image (handles provider swap, env key)
+        const buffer = await mapService.getStaticMapImage(lat, lng, {
+          size: "400x500",
+          zoom: 15,
+        });
         const uniqueName = uuidv4();
         const fileName = path.join(
           __dirname,
           `../../../${uniqueName}-location.jpeg`,
         );
-        const buffer = Buffer.from(response.data);
         const imageBuffer = await changeBufferToImage(buffer, fileName, "jpeg");
 
         locationImage = await uploadToFirebase(
@@ -1485,17 +1488,20 @@ const updateMerchantDetailsController = async (req, res, next) => {
       !arraysAreEqual(newLocation, existingCoords)
     ) {
       const [lng, lat] = newLocation;
-      const url = `https://apis.mapmyindia.com/advancedmaps/v1/9a632cda78b871b3a6eb69bddc470fef/still_image?center=${lng},${lat}&size=400x500&markers=${lng},${lat}&zoom=15`;
 
       try {
-        console.log(url);
-        const response = await axios.get(url, { responseType: "arraybuffer" });
+        console.log("Generating location image via MapService");
+
+        // Use MapService for static map image (handles provider swap, env key)
+        const buffer = await mapService.getStaticMapImage(lat, lng, {
+          size: "400x500",
+          zoom: 15,
+        });
         const uniqueName = uuidv4();
         const fileName = path.join(
           __dirname,
           `../../../${uniqueName}-location.jpeg`,
         );
-        const buffer = Buffer.from(response.data);
         const imageBuffer = await changeBufferToImage(buffer, fileName, "jpeg");
 
         locationImage = await uploadToFirebase(

--- a/controllers/admin/order/merchantOrderController.js
+++ b/controllers/admin/order/merchantOrderController.js
@@ -29,10 +29,10 @@ const {
 const {
   orderCreateTaskHelper,
 } = require("../../../utils/orderCreateTaskHelper");
+const mapService = require("../../../services/MapService");
 const { razorpayRefund } = require("../../../utils/razorpayPayment");
 const {
   reduceProductAvailableQuantity,
-  getDistanceFromPickupToDelivery,
   calculateDeliveryCharges,
 } = require("../../../utils/customerAppHelpers");
 const {
@@ -2677,7 +2677,7 @@ const createOrderFromExternalMerchant = async (req, res, next) => {
       });
     }
 
-    const { distanceInKM } = await getDistanceFromPickupToDelivery(
+    const { distanceInKM } = await mapService.getDistance(
       merchant.merchantDetail.geoLocation.coordinates,
       address.coordinates,
     );

--- a/controllers/agent/agentController.js
+++ b/controllers/agent/agentController.js
@@ -45,10 +45,8 @@ const {
   updateCustomerSubscriptionCount,
   updateAgentDetailsForBatch,
 } = require("../../utils/agentAppHelpers");
+const mapService = require("../../services/MapService");
 const { formatDate, formatTime } = require("../../utils/formatters");
-const {
-  getDistanceFromPickupToDelivery,
-} = require("../../utils/customerAppHelpers");
 const {
   createRazorpayOrderId,
   verifyPayment,
@@ -2773,7 +2771,7 @@ const updateCustomOrderStatusController = async (req, res, next) => {
     //   shopUpdates?.length !== 1 &&
     //   orderFound?.orderDetail?.pickupLocation?.length === 2
     // ) {
-    const { distanceInKM } = await getDistanceFromPickupToDelivery(
+    const { distanceInKM } = await mapService.getDistance(
       lastLocation,
       location
     );

--- a/controllers/customer/customOrderController.js
+++ b/controllers/customer/customOrderController.js
@@ -23,6 +23,7 @@ const { formatDate, formatTime } = require("../../utils/formatters");
 const { sendSocketDataAndNotification } = require("../../utils/socketHelper");
 
 const { findRolesToNotify } = require("../../socket/socket");
+const { geoLocation } = require("../../utils/getGeoLocation");
 
 const addShopController = async (req, res, next) => {
   try {
@@ -562,6 +563,34 @@ const confirmCustomOrderController = async (req, res, next) => {
 
     if (!customer) return next(appError("Customer not found", 404));
     if (!cart) return next(appError("Cart not found", 404));
+
+    // ── Geofence validation ─────────────────────────────────────────────
+    // Custom Order uses the same PickAndCustomCart schema as Pick & Drop.
+    // Validate the first pickup address coordinates against active geofences
+    // at the final order-creation gateway. This file had NO geofence check
+    // at all — it was the most exposed gap.
+    const firstPickup = cart.pickups?.[0];
+    if (
+      !firstPickup?.location ||
+      !Array.isArray(firstPickup.location) ||
+      firstPickup.location.length < 2
+    ) {
+      return next(
+        appError("Pickup location coordinates are missing or invalid", 400),
+      );
+    }
+    const orderGeofence = await geoLocation(
+      firstPickup.location[0],
+      firstPickup.location[1],
+    );
+    if (!orderGeofence) {
+      return next(
+        appError(
+          "Pickup location is outside our service area. Please choose a different pickup address.",
+          400,
+        ),
+      );
+    }
 
     const orderAmount =
       cart.billDetail.discountedGrandTotal ||

--- a/controllers/customer/customOrderController.js
+++ b/controllers/customer/customOrderController.js
@@ -11,8 +11,8 @@ const CustomerTransaction = require("../../models/CustomerTransactionDetail");
 const ActivityLog = require("../../models/ActivityLog");
 
 const appError = require("../../utils/appError");
+const mapService = require("../../services/MapService");
 const {
-  getDistanceFromPickupToDelivery,
   getDeliveryAndSurgeCharge,
 } = require("../../utils/customerAppHelpers");
 const {
@@ -50,7 +50,7 @@ const addShopController = async (req, res, next) => {
       deliveryLocation = customer.customerDetails.location;
 
       const { distanceInKM, durationInMinutes } =
-        await getDistanceFromPickupToDelivery(pickupLocation, deliveryLocation);
+        await mapService.getDistance(pickupLocation, deliveryLocation);
 
       distance = distanceInKM;
       duration = durationInMinutes;
@@ -402,7 +402,7 @@ const addDeliveryAddressController = async (req, res, next) => {
       deliveryLocation = deliveryCoordinates;
 
       const { distanceInKM, durationInMinutes } =
-        await getDistanceFromPickupToDelivery(pickupLocation, deliveryLocation);
+        await mapService.getDistance(pickupLocation, deliveryLocation);
 
       distance = parseFloat(distanceInKM);
       duration = parseInt(durationInMinutes);

--- a/controllers/customer/pickAndDropController.js
+++ b/controllers/customer/pickAndDropController.js
@@ -1195,9 +1195,9 @@ const CustomerWalletTransaction = require("../../models/CustomerWalletTransactio
 const ActivityLog = require("../../models/ActivityLog");
 
 const appError = require("../../utils/appError");
+const mapService = require("../../services/MapService");
 const {
   calculateDeliveryCharges,
-  getDistanceFromMultipleCoordinates,
   filterCoordinatesFromData,
 } = require("../../utils/customerAppHelpers");
 const {
@@ -1252,7 +1252,7 @@ const addPickUpAddressController = async (req, res, next) => {
 
     console.log(coordinates);
 
-    const { distanceInKM, duration } = await getDistanceFromMultipleCoordinates(
+    const { distanceInKM, duration } = await mapService.getDistanceMulti(
       coordinates
     );
 

--- a/controllers/customer/pickAndDropController.js
+++ b/controllers/customer/pickAndDropController.js
@@ -1626,6 +1626,35 @@ const confirmPickAndDropController = async (req, res, next) => {
     if (!customer) return next(appError("Customer not found", 404));
     if (!cart) return next(appError("Cart not found", 404));
 
+    // ── Geofence validation ─────────────────────────────────────────────
+    // Re-validate the pickup location against active geofences at the final
+    // order-creation gateway. The pricing step (getVehiclePricingDetailsCtrl)
+    // checks this, but it's a checkpoint — this gateway must re-validate
+    // to catch tampered cart data or deleted/resized geofences.
+    // Pick & Drop → validate the first pickup address coordinates.
+    const firstPickup = cart.pickups?.[0];
+    if (
+      !firstPickup?.location ||
+      !Array.isArray(firstPickup.location) ||
+      firstPickup.location.length < 2
+    ) {
+      return next(
+        appError("Pickup location coordinates are missing or invalid", 400),
+      );
+    }
+    const orderGeofence = await geoLocation(
+      firstPickup.location[0],
+      firstPickup.location[1],
+    );
+    if (!orderGeofence) {
+      return next(
+        appError(
+          "Pickup location is outside our service area. Please choose a different pickup address.",
+          400,
+        ),
+      );
+    }
+
     const orderAmount = parseFloat(
       cart.billDetail.discountedGrandTotal || cart.billDetail.originalGrandTotal
     );
@@ -1920,6 +1949,35 @@ const verifyPickAndDropPaymentController = async (req, res, next) => {
 
     if (!cart) {
       return next(appError("Cart not found", 404));
+    }
+
+    // ── Geofence validation ─────────────────────────────────────────────
+    // Re-validate the pickup location against active geofences at this
+    // payment-verification gateway. This catches the same tamper window
+    // as confirmPickAndDropController — the user could have modified cart
+    // data or geofence boundaries could have changed between the pricing
+    // checkpoint and the payment-confirmed order creation.
+    const firstPickup = cart.pickups?.[0];
+    if (
+      !firstPickup?.location ||
+      !Array.isArray(firstPickup.location) ||
+      firstPickup.location.length < 2
+    ) {
+      return next(
+        appError("Pickup location coordinates are missing or invalid", 400),
+      );
+    }
+    const orderGeofence = await geoLocation(
+      firstPickup.location[0],
+      firstPickup.location[1],
+    );
+    if (!orderGeofence) {
+      return next(
+        appError(
+          "Pickup location is outside our service area. Please choose a different pickup address.",
+          400,
+        ),
+      );
     }
 
     const orderAmount =

--- a/controllers/customer/universalOrderController.js
+++ b/controllers/customer/universalOrderController.js
@@ -2169,6 +2169,30 @@ const orderPaymentController = async (req, res, next) => {
 
     if (!merchant) return next(appError("Merchant not found", 404));
 
+    // ── Geofence validation ─────────────────────────────────────────────
+    // Re-validate the delivery address against active geofences at the
+    // final order-creation gateway. The coordinates were validated earlier
+    // in confirmOrderDetailController (checkpoint), but the geofence could
+    // have been deleted/resized, or the cart data could have been tampered
+    // with between that step and this one.
+    // Home Delivery → validate cart.cartDetail.deliveryLocation
+    const deliveryLocation = cart.cartDetail?.deliveryLocation;
+    if (!Array.isArray(deliveryLocation) || deliveryLocation.length < 2) {
+      return next(appError("Delivery location coordinates are missing", 400));
+    }
+    const orderGeofence = await geoLocation(
+      deliveryLocation[0],
+      deliveryLocation[1],
+    );
+    if (!orderGeofence) {
+      return next(
+        appError(
+          "Delivery address is outside our service area. Please choose a different address.",
+          400,
+        ),
+      );
+    }
+
     const deliveryTimeMinutes = parseInt(
       merchant.merchantDetail.deliveryTime,
       10,

--- a/controllers/customer/universalOrderController.js
+++ b/controllers/customer/universalOrderController.js
@@ -21,9 +21,10 @@ const CustomerTransaction = require("../../models/CustomerTransactionDetail");
 const CustomerWalletTransaction = require("../../models/CustomerWalletTransaction");
 const WebhookEvent = require("../../models/WebhookEvent");
 
+const mapService = require("../../services/MapService");
+
 const {
   sortMerchantsBySponsorship,
-  getDistanceFromPickupToDelivery,
   calculateDiscountedPrice,
   filterProductIdAndQuantity,
   fetchCustomerAndMerchantAndCart,
@@ -517,7 +518,7 @@ const getMerchantData = async (req, res, next) => {
 
         const customerLocation = [Number(latitude), Number(longitude)];
 
-        const distance = await getDistanceFromPickupToDelivery(
+        const distance = await mapService.getDistance(
           merchantLocation,
           customerLocation,
         );

--- a/services/MapService.js
+++ b/services/MapService.js
@@ -1,0 +1,204 @@
+const NodeCache = require("node-cache");
+const mappls = require("./providers/mapplsProvider");
+
+// ---------------------------------------------------------------------------
+// MapService — single point of contact for all map-related operations
+// ---------------------------------------------------------------------------
+// What this does:
+//   1. Accepts pickup/delivery coordinates in [lat, lng] format
+//   2. Checks in-memory cache → if hit, returns instantly (zero cost)
+//   3. If cache miss, delegates to the active provider (today: Mappls)
+//   4. Stores the result in cache, returns it
+//
+// Caching rules:
+//   - Cache key = rounded coordinates (3 decimal = ~100m) + profile
+//   - TTL = 300 seconds (5 minutes) — roads don't change that fast
+//   - If every order asks the same restaurant → delivery area route,
+//     the cache absorbs ~80% of repeat calls
+//
+// To switch provider: change this.provider to a new module that exports
+// the same { distance(...), routePolyline(...), staticMapImage(...) } shape.
+// ---------------------------------------------------------------------------
+
+class MapService {
+  constructor() {
+    this.cache = new NodeCache({ stdTTL: 300, checkperiod: 60 });
+    this.provider = mappls; // swap here when adding OSRM / LocationIQ
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal helpers
+  // -----------------------------------------------------------------------
+
+  /** Build a deterministic cache key from coordinates + profile */
+  _cacheKey(lat1, lng1, lat2, lng2, profile) {
+    // Round to 3 decimals (~100m precision) so minor GPS jitter still hits cache
+    return `${lat1.toFixed(3)},${lng1.toFixed(3)}|${lat2.toFixed(3)},${lng2.toFixed(3)}|${profile}`;
+  }
+
+  /** Try cache first; on miss call provider, cache result, return */
+  async _cachedOrFetch(key, fetcher) {
+    const cached = this.cache.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const result = await fetcher();
+    this.cache.set(key, result);
+    return result;
+  }
+
+  // -----------------------------------------------------------------------
+  // Coordinate normalisation
+  // -----------------------------------------------------------------------
+  // The app stores coordinates in inconsistent formats across models:
+  //   - Some as [lat, lng]           (MongoDB GeoJSON — correct)
+  //   - Some as [lng, lat]           (legacy / accidental swap)
+  //   - Some as "lat,lng" string     (from CSV imports / form inputs)
+  //   - Some as { lat, lng } objects (from some controllers)
+  //
+  // normalize() handles all variants and returns [lat, lng] consistently,
+  // so the provider layer always gets reliable values.
+
+  /**
+   * Convert any input format to [lat, lng].
+   * Returns null if input can't be parsed.
+   *
+   * @param {any} input
+   * @returns {[number, number] | null}
+   */
+  normalize(input) {
+    if (!input) return null;
+
+    // "lat,lng" string
+    if (typeof input === "string") {
+      const parts = input.split(",");
+      if (parts.length !== 2) return null;
+      return [Number(parts[0]), Number(parts[1])];
+    }
+
+    // { lat, lng } or { latitude, longitude } object
+    if (!Array.isArray(input)) {
+      const lat = input.lat ?? input.latitude;
+      const lng = input.lng ?? input.longitude;
+      if (lat == null || lng == null) return null;
+      return [Number(lat), Number(lng)];
+    }
+
+    // Array — could be [lat, lng] or [lng, lat]
+    if (input.length !== 2) return null;
+
+    let a = Number(input[0]);
+    let b = Number(input[1]);
+
+    if (Number.isNaN(a) || Number.isNaN(b)) return null;
+
+    // Heuristic: if first value looks like longitude (>90 absolute) → swap
+    if (Math.abs(a) > 90 && Math.abs(b) <= 90) {
+      return [b, a]; // was [lng, lat] → [lat, lng]
+    }
+
+    return [a, b]; // already [lat, lng]
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API — these are what the rest of the app calls
+  // -----------------------------------------------------------------------
+
+  /**
+   * Get road distance and duration between two points.
+   *
+   * @param   {any}  pickup    — pickup location in any supported format
+   * @param   {any}  delivery  — delivery location in any supported format
+   * @param   {'driving'|'biking'|'walking'} [profile='biking']
+   * @returns {Promise<{distanceInKM: number, durationInMinutes: number}>}
+   */
+  async getDistance(pickup, delivery, profile = "biking") {
+    const p = this.normalize(pickup);
+    const d = this.normalize(delivery);
+
+    if (!p || !d) {
+      throw new Error(
+        `Invalid coordinates for getDistance — pickup: ${JSON.stringify(pickup)}, delivery: ${JSON.stringify(delivery)}`
+      );
+    }
+
+    const [lat1, lng1] = p;
+    const [lat2, lng2] = d;
+    const key = this._cacheKey(lat1, lng1, lat2, lng2, profile);
+
+    return this._cachedOrFetch(key, () =>
+      this.provider.distance(lat1, lng1, lat2, lng2, profile)
+    );
+  }
+
+  /**
+   * Get distance across multiple waypoints (chain: c0→c1, c1→c2, ...).
+   * Each waypoint must be { lat, lng }.
+   *
+   * @param   {Array<{lat: number, lng: number}>}  coordinates
+   * @param   {'driving'|'biking'|'walking'} [profile='biking']
+   * @returns {Promise<{distanceInKM: number, durationInMinutes: number}>}
+   */
+  async getDistanceMulti(coordinates, profile = "biking") {
+    if (!coordinates || coordinates.length < 2) {
+      throw new Error("At least 2 coordinates required for getDistanceMulti");
+    }
+
+    let totalDistanceMeters = 0;
+    let totalDurationSeconds = 0;
+
+    for (let i = 0; i < coordinates.length - 1; i++) {
+      const from = this.normalize(coordinates[i]);
+      const to = this.normalize(coordinates[i + 1]);
+      if (!from || !to) {
+        throw new Error(`Invalid coordinate pair at index ${i}`);
+      }
+
+      const [lat1, lng1] = from;
+      const [lat2, lng2] = to;
+      const key = this._cacheKey(lat1, lng1, lat2, lng2, profile);
+
+      // eslint-disable-next-line no-await-in-loop
+      const seg = await this._cachedOrFetch(key, () =>
+        this.provider.distance(lat1, lng1, lat2, lng2, profile)
+      );
+
+      // seg.distanceInKM is already in km; multiply back to meters for accumulation
+      totalDistanceMeters += seg.distanceInKM * 1000;
+      totalDurationSeconds += seg.durationInMinutes * 60;
+    }
+
+    return {
+      distanceInKM: Number((totalDistanceMeters / 1000).toFixed(2)),
+      durationInMinutes: Math.ceil(totalDurationSeconds / 60),
+    };
+  }
+
+  /**
+   * Get a route polyline for map display.
+   *
+   * @param   {Array<[number, number]>}  path    — array of [lat, lng] waypoints
+   * @param   {'driving'|'biking'|'walking'} [profile='biking']
+   * @returns {Promise<object>} raw Mappls GeoJSON response
+   */
+  async getRoutePolyline(path, profile = "biking") {
+    return this.provider.routePolyline(path, profile);
+  }
+
+  /**
+   * Get a static map image (merchant location thumbnail).
+   *
+   * @param   {any}     center  — center point in any supported format
+   * @param   {object}  [options]
+   * @returns {Promise<Buffer>}
+   */
+  async getStaticMapImage(center, options = {}) {
+    const c = this.normalize(center);
+    if (!c) throw new Error(`Invalid center for static map: ${JSON.stringify(center)}`);
+    const [lat, lng] = c;
+    return this.provider.staticMapImage(lat, lng, options);
+  }
+}
+
+// Singleton — every importer shares the same cache instance
+module.exports = new MapService();

--- a/services/providers/mapplsProvider.js
+++ b/services/providers/mapplsProvider.js
@@ -1,0 +1,99 @@
+const axios = require("axios");
+
+// ---------------------------------------------------------------------------
+// Mappls (MapMyIndia) Provider
+// ---------------------------------------------------------------------------
+// This is the ONLY file that constructs Mappls API URLs or touches the raw
+// response format. Everything else in the app goes through MapService.js,
+// which delegates here.
+//
+// To switch Mappls for another provider, you write a new provider file
+// (e.g. osrmProvider.js) that exposes the same functions and swap the
+// reference in MapService.js — no other file changes.
+// ---------------------------------------------------------------------------
+
+/** Return the API key from env (lazy-loaded so .env has loaded by first call) */
+const apiKey = () => {
+  const key = process.env.MapMyIndiaAPIKey;
+  if (!key) throw new Error("MapMyIndiaAPIKey not set in environment");
+  return key;
+};
+
+/**
+ * Get road distance and duration between two points.
+ *
+ * @param {number} lat1  - pickup latitude
+ * @param {number} lng1  - pickup longitude
+ * @param {number} lat2  - delivery latitude
+ * @param {number} lng2  - delivery longitude
+ * @param {'driving'|'biking'|'walking'} [profile='biking']
+ * @returns {Promise<{distanceInKM: number, durationInMinutes: number}>}
+ */
+async function distance(lat1, lng1, lat2, lng2, profile = "biking") {
+  // Mappls Distance Matrix API expects coordinates as lng,lat
+  const url = `https://apis.mapmyindia.com/advancedmaps/v1/${apiKey()}/distance_matrix/${profile}/${lng1},${lat1};${lng2},${lat2}`;
+
+  const { data } = await axios.get(url);
+
+  const matrix = data?.results?.distances?.[0];
+  const durationMatrix = data?.results?.durations?.[0];
+
+  if (!Array.isArray(matrix) || !Array.isArray(durationMatrix)) {
+    throw new Error("No distance matrix returned from Mappls");
+  }
+
+  // matrix is [[0, distance_meters]] — index [1] is the value we want
+  const distanceMeters = matrix[1] ?? matrix[0];
+  const durationSeconds = durationMatrix[1] ?? durationMatrix[0];
+
+  if (distanceMeters == null) {
+    throw new Error("Distance not found in Mappls matrix response");
+  }
+
+  return {
+    distanceInKM: Number((distanceMeters / 1000).toFixed(2)),
+    durationInMinutes: Math.ceil((durationSeconds || 0) / 60),
+  };
+}
+
+/**
+ * Get a route polyline (the path line drawn on the map).
+ *
+ * @param {Array<[number, number]>} path  - array of [lat, lng] waypoints
+ * @param {'driving'|'biking'|'walking'} [profile='biking']
+ * @returns {Promise<object>}  raw GeoJSON response from Mappls
+ */
+async function routePolyline(path, profile = "biking") {
+  // Mappls Route Advanced API needs lng,lat;lng,lat;...
+  const coordStr = path
+    .map(([lat, lng]) => `${lng},${lat}`)
+    .join(";");
+
+  const url = `https://apis.mapmyindia.com/advancedmaps/v1/${apiKey()}/route_adv/${profile}/${coordStr}?geometries=geojson`;
+
+  const { data } = await axios.get(url);
+  return data;
+}
+
+/**
+ * Get a static map image (used for merchant location thumbnails).
+ *
+ * @param {number} lat
+ * @param {number} lng
+ * @param {object} [options]
+ * @param {string}  [options.size='400x500']
+ * @param {number}  [options.zoom=15]
+ * @param {string}  [options.key]  - optional API key override (some endpoints use a different key)
+ * @returns {Promise<Buffer>} raw image bytes
+ */
+async function staticMapImage(lat, lng, options = {}) {
+  const { size = "400x500", zoom = 15, key } = options;
+  const activeKey = key || apiKey();
+
+  const url = `https://apis.mapmyindia.com/advancedmaps/v1/${activeKey}/still_image?center=${lng},${lat}&size=${size}&markers=${lng},${lat}&zoom=${zoom}`;
+
+  const response = await axios.get(url, { responseType: "arraybuffer" });
+  return response.data;
+}
+
+module.exports = { distance, routePolyline, staticMapImage };

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -13,8 +13,8 @@ const Conversation = require("../models/Conversation");
 const CustomerNotificationLogs = require("../models/CustomerNotificationLog");
 const AdminNotificationLogs = require("../models/AdminNotificationLog");
 const MerchantNotificationLogs = require("../models/MerchantNotificationLog");
+const mapService = require("../services/MapService");
 const {
-  getDistanceFromPickupToDelivery,
   getDeliveryAndSurgeCharge,
 } = require("../utils/customerAppHelpers");
 const {
@@ -2083,7 +2083,7 @@ io.on("connection", async (socket) => {
               // ADD: Calculate start-to-pick distance for batch order
               const pickupStartedLoc = order.orderDetailStepper?.pickupStarted?.location;
               if (pickupStartedLoc?.length === 2 && agentLocation?.length === 2) {
-                const { distanceInKM } = await getDistanceFromPickupToDelivery(
+                const { distanceInKM } = await mapService.getDistance(
                   pickupStartedLoc,
                   agentLocation
                 );
@@ -2241,7 +2241,7 @@ io.on("connection", async (socket) => {
           // Calculate start-to-pick distance (agent's travel from start to merchant)
           const pickupStartLocation = orderFound.orderDetailStepper?.pickupStarted?.location;
           if (pickupStartLocation?.length === 2 && agentLocation?.length === 2) {
-            const { distanceInKM } = await getDistanceFromPickupToDelivery(
+            const { distanceInKM } = await mapService.getDistance(
               pickupStartLocation,   // where agent was when they tapped "Start Pickup"
               agentLocation          // where agent is now (at the merchant)
             );
@@ -2392,7 +2392,7 @@ io.on("connection", async (socket) => {
   //       !orderFound?.detailAddedByAgent?.distanceCoveredByAgent &&
   //       orderFound?.detailAddedByAgent?.distanceCoveredByAgent !== 0
   //     ) {
-  //       const { distanceInKM } = await getDistanceFromPickupToDelivery(
+  //       const { distanceInKM } = await mapService.getDistance(
   //         agentLocation,
   //         pickupLocation
   //       );
@@ -3200,7 +3200,7 @@ io.on("connection", async (socket) => {
           let distanceCoveredByAgent = 0;
           try {
             if (orderFound?.deliveryMode === "Custom Order") {
-              const { distanceInKM } = await getDistanceFromPickupToDelivery(
+              const { distanceInKM } = await mapService.getDistance(
                 location,
                 delivery.location
               );
@@ -3510,7 +3510,7 @@ io.on("connection", async (socket) => {
               agentLocation?.length === 2
             ) {
               const { distanceInKM } =
-                await getDistanceFromPickupToDelivery(
+                await mapService.getDistance(
                   deliveryStartedLocation,
                   agentLocation
                 );
@@ -3725,7 +3725,7 @@ io.on("connection", async (socket) => {
             agentLocation?.length === 2
           ) {
             const { distanceInKM } =
-              await getDistanceFromPickupToDelivery(
+              await mapService.getDistance(
                 deliveryStartedLocation,
                 agentLocation
               );
@@ -3960,7 +3960,7 @@ io.on("connection", async (socket) => {
   //           // ADD: Calculate pick-to-delivery distance for batch order
   //           const delivStartLoc = orderFound.orderDetailStepper?.deliveryStarted?.location;
   //           if (delivStartLoc?.length === 2 && agentLocation?.length === 2) {
-  //             const { distanceInKM } = await getDistanceFromPickupToDelivery(
+  //             const { distanceInKM } = await mapService.getDistance(
   //               delivStartLoc,
   //               agentLocation
   //             );
@@ -4074,7 +4074,7 @@ io.on("connection", async (socket) => {
   //         // Calculate pick-to-delivery distance (agent's actual travel from merchant to customer)
   //         const deliveryStartedLocation = orderFound.orderDetailStepper?.deliveryStarted?.location;
   //         if (deliveryStartedLocation?.length === 2 && agentLocation?.length === 2) {
-  //           const { distanceInKM } = await getDistanceFromPickupToDelivery(
+  //           const { distanceInKM } = await mapService.getDistance(
   //             deliveryStartedLocation,  // where agent was when they left the merchant
   //             agentLocation             // where agent is now (at customer)
   //           );
@@ -4224,7 +4224,7 @@ io.on("connection", async (socket) => {
   //         let distanceCoveredByAgent = 0;
 
   //         if (orderFound?.deliveryMode === "Custom Order") {
-  //           const { distanceInKM } = await getDistanceFromPickupToDelivery(
+  //           const { distanceInKM } = await mapService.getDistance(
   //             location,
   //             delivery.location
   //           );
@@ -4407,7 +4407,7 @@ io.on("connection", async (socket) => {
   //     let distanceCoveredByAgent = 0;
 
   //     if (orderFound.orderDetail.deliveryMode === "Custom Order") {
-  //       const { distanceInKM } = await getDistanceFromPickupToDelivery(
+  //       const { distanceInKM } = await mapService.getDistance(
   //         location,
   //         orderFound.orderDetail.deliveryLocation
   //       );
@@ -4857,7 +4857,7 @@ io.on("connection", async (socket) => {
           orderFound.detailAddedByAgent?.shopUpdates?.slice(-1)?.[0]
             ?.location || null;
 
-        const { distanceInKM } = await getDistanceFromPickupToDelivery(
+        const { distanceInKM } = await mapService.getDistance(
           dataByAgent.location,
           lastLocation
         );

--- a/utils/createOrderHelpers.js
+++ b/utils/createOrderHelpers.js
@@ -17,10 +17,10 @@ const { convertISTToUTC } = require("./formatters");
 
 const { geoLocation } = require("./getGeoLocation");
 
+const mapService = require("../services/MapService");
 const {
   calculateDeliveryCharges,
   getTaxAmount,
-  getDistanceFromPickupToDelivery,
   filterProductIdAndQuantity,
   calculateReturnCharges,
 } = require("./customerAppHelpers");
@@ -768,7 +768,7 @@ const handleDeliveryMode = async (
     const fromLocation = normalizeLatLng(rawFrom);
 
     if (fromLocation?.length === 2 && addressDetails.deliveryLocation?.length === 2) {
-      const { distanceInKM } = await getDistanceFromPickupToDelivery(
+      const { distanceInKM } = await mapService.getDistance(
         fromLocation,
         addressDetails.deliveryLocation
       );
@@ -1383,7 +1383,7 @@ const handleDeliveryModeForAdmin = async (
   let distance = 0;
 
   if (deliveryMode !== "Take Away" && pickupStr) {
-    const result = await getDistanceFromPickupToDelivery(
+    const result = await mapService.getDistance(
       pickupStr,
       deliveryStr
     );
@@ -1465,7 +1465,7 @@ const handleDeliveryModeForAdmin = async (
 //     delivery;
 
 //   if (isValidRoute) {
-//     const result = await getDistanceFromPickupToDelivery(
+//     const result = await mapService.getDistance(
 //       pickup,
 //       delivery
 //     );
@@ -2179,7 +2179,7 @@ const processHomeDeliveryDetailInApp = async (
     }
 
     if (pickupLocation.length) {
-      const { distanceInKM } = await getDistanceFromPickupToDelivery(
+      const { distanceInKM } = await mapService.getDistance(
         pickupLocation,
         deliveryLocation
       );

--- a/utils/customerAppHelpers.js
+++ b/utils/customerAppHelpers.js
@@ -1,4 +1,4 @@
-const axios = require("axios");
+const mapService = require("../services/MapService");
 
 const Tax = require("../models/Tax");
 const Order = require("../models/Order");
@@ -50,6 +50,19 @@ const filterCoordinatesFromData = (parsedData) => {
   return coordinates;
 };
 
+// ---------------------------------------------------------------------------
+// Bridge to MapService abstraction
+// ---------------------------------------------------------------------------
+// These functions now delegate to services/MapService.js, which handles
+// caching, provider selection, and normalisation centrally.
+//
+// The old direct Mappls API calls have been moved to
+// services/providers/mapplsProvider.js — the ONLY file that touches
+// mapmyindia.com URLs.
+//
+// Callers importing these functions work exactly as before.
+// ---------------------------------------------------------------------------
+
 const getDistanceFromPickupToDelivery = async (
   pickupCoordinates,
   deliveryCoordinates,
@@ -58,121 +71,24 @@ const getDistanceFromPickupToDelivery = async (
   console.log("pickupcordinates", pickupCoordinates);
   console.log("deliverycordinates", deliveryCoordinates);
 
-  // -----------------------------
-  // CONVERT ANY INPUT → [lat,lng]
-  // -----------------------------
-  const normalize = (input) => {
-    if (!input) return null;
+  // MapService.normalize() handles all input formats (string, array, object)
+  // and returns [lat, lng] consistently
+  const result = await mapService.getDistance(
+    pickupCoordinates,
+    deliveryCoordinates,
+    profile
+  );
 
-    // if string "lat,lng"
-    if (typeof input === "string") {
-      const parts = input.split(",");
-      if (parts.length !== 2) return null;
-      return [Number(parts[0]), Number(parts[1])];
-    }
-
-    if (!Array.isArray(input)) return null;
-    if (input.length !== 2) return null;
-
-    let a = Number(input[0]);
-    let b = Number(input[1]);
-
-    if (Number.isNaN(a) || Number.isNaN(b)) return null;
-
-    // detect lng,lat → swap
-    if (Math.abs(a) > 90 && Math.abs(b) <= 90) {
-      return [b, a];
-    }
-
-    return [a, b];
-  };
-
-  const pickup = normalize(pickupCoordinates);
-  const delivery = normalize(deliveryCoordinates);
-
-  if (!pickup || !delivery) {
-    console.log("Error: invalid input after normalization");
-    throw new Error("Invalid coordinates to find the distance");
-  }
-
-  const [pickLat, pickLng] = pickup;
-  const [delLat, delLng] = delivery;
-
-  // MapMyIndia expects lng,lat
-  const url = `https://apis.mapmyindia.com/advancedmaps/v1/${
-    process.env.MapMyIndiaAPIKey
-  }/distance_matrix/${profile}/${pickLng},${pickLat};${delLng},${delLat}`;
-
-  console.log("Distance URL:", url);
-
-  const { data } = await axios.get(url);
-
-  console.log("MapMyIndia response:", JSON.stringify(data, null, 2));
-
-  const matrix = data?.results?.distances?.[0];
-  const durationMatrix = data?.results?.durations?.[0];
-
-  if (!Array.isArray(matrix) || !Array.isArray(durationMatrix)) {
-    throw new Error("No distance matrix returned from MapMyIndia");
-  }
-
-  const distanceMeters = matrix[1] ?? matrix[0];
-  const durationSeconds = durationMatrix[1] ?? durationMatrix[0];
-
-  if (distanceMeters == null) {
-    throw new Error("Distance not found in matrix");
-  }
-
-  const distanceInKM = Number((distanceMeters / 1000).toFixed(2));
-  const durationInMinutes = Math.ceil((durationSeconds || 0) / 60);
-
-  console.log("Distance in KM:", distanceInKM);
-
-  return {
-    distanceInKM,
-    durationInMinutes,
-  };
+  console.log("Distance in KM:", result.distanceInKM);
+  return result;
 };
 
 const getDistanceFromMultipleCoordinates = async (
   coordinates,
   profile = "biking"
 ) => {
-  if (!coordinates || coordinates.length < 2) {
-    throw new Error("At least 2 coordinates required");
-  }
-
-  let totalDistanceMeters = 0;
-  let totalDurationSeconds = 0;
-
-  for (let i = 0; i < coordinates.length - 1; i++) {
-    const from = `${coordinates[i].lng},${coordinates[i].lat}`;
-    const to = `${coordinates[i + 1].lng},${coordinates[i + 1].lat}`;
-
-    const { data } = await axios.get(
-      `https://apis.mapmyindia.com/advancedmaps/v1/${process.env.MapMyIndiaAPIKey}/distance_matrix/${profile}/${from};${to}`
-    );
-
-    const distance = data?.results?.distances?.[0]?.[1];
-    const duration = data?.results?.durations?.[0]?.[1];
-
-    if (!distance || !duration) {
-      throw new Error("Distance API failed");
-    }
-
-    totalDistanceMeters += distance;
-    totalDurationSeconds += duration;
-  }
-
-  const distanceInKM = parseFloat(
-    (totalDistanceMeters / 1000).toFixed(2)
-  );
-
-  const durationInMinutes = Math.ceil(
-    totalDurationSeconds / 60
-  );
-
-  return { distanceInKM, durationInMinutes };
+  // Delegates to MapService which handles caching per segment
+  return mapService.getDistanceMulti(coordinates, profile);
 };
 
 // const getDistanceFromMultipleCoordinates = async (


### PR DESCRIPTION
# Map Service Abstraction — Migration Report

> **Date:** July 2026
> **Scope:** Backend-only refactor. All Mappls/MapMyIndia API calls now route through a single `MapService` interface.
> **No frontend changes required.**

---

## What Changed

### Old Architecture

Distance, route polyline, and static map calls were scattered across **10+ files** with raw URL construction, inline axios/fetch calls, and duplicate normalisation logic. Every call hit Mappls directly — paid per request, no caching, no fallback.

```
socket.js ────────────────────────────────────────────→ Mappls API
utils/customerAppHelpers.js ── getDistanceFromPickupToDelivery() → Mappls
utils/createOrderHelpers.js ── inline normalizer + call → Mappls
controllers/admin/map/mapController.js ── raw axios → Mappls
controllers/admin/merchant/merchantController.js ── hardcoded API key → Mappls
controllers/agent/agentController.js ── via customerAppHelpers → Mappls
controllers/admin/order/merchantOrderController.js ── via helpers → Mappls
controllers/admin/deliveryManagement/taskController.js ── via helpers → Mappls
controllers/customer/universalOrderController.js ── via helpers → Mappls
controllers/customer/customOrderController.js ── via helpers → Mappls
controllers/customer/pickAndDropController.js ── via helpers → Mappls
```

**Problems:**
- To switch providers, edit **all 10+ files**
- `MapMyIndiaAPIKey` referenced in 5+ places
- Hardcoded API key `9a632cda78b871b3a6eb69bddc470fef` in `merchantController.js` (lines 525, 1488)
- Normalisation logic (`[lat,lng]` vs `[lng,lat]`) duplicated 4 times across files
- Zero caching — same route calculated 20+ times per order
- Dead OAuth token generation in `tokenOperation.js` generated and stored but **never used**

---

### New Architecture

```
Every caller → MapService.getDistance() / .getDistanceMulti() / .getRoutePolyline() / .getStaticMapImage()
                            │
                    ┌───────┴───────┐
                    │               │
              node-cache      providers/
              (300s TTL)     mapplsProvider.js
                                  │
                            Mappls API
              (Future: osrmProvider.js → self-hosted OSRM)
```

**Single source of truth** for:
- Provider selection (change `this.provider` in MapService, one line)
- URL construction
- Auth (API key read from env in one place)
- Response parsing
- Coordinate normalisation (5 input formats handled)
- Caching

---

## Files Created

### `services/MapService.js`
The orchestrator. Every map operation in the app calls this module.

**Methods:**

| Method | Params | Returns | Used by |
|---|---|---|---|
| `getDistance(pickup, delivery, profile)` | `pickup, delivery`: any format (string, array, object), `profile`: biking/driving/walking | `{ distanceInKM, durationInMinutes }` | All distance callers |
| `getDistanceMulti(coordinates, profile)` | `coordinates`: array of `{lat, lng}` objects | `{ distanceInKM, durationInMinutes }` | pickAndDropController |
| `getRoutePolyline(path, profile)` | `path`: array of `[lat, lng]` | Raw GeoJSON from provider | mapController |
| `getStaticMapImage(center, options)` | `center`: any format, `options.size, zoom, key` | `Buffer` (image bytes) | merchantController |
| `normalize(input)` | `input`: string, array, object, null | `[lat, lng]` or null | Used by controllers directly for coordinate validation |

**Caching:**
- `node-cache` with 300s TTL
- Cache key = `${lat1},${lng1}|${lat2},${lng2}|${profile}` rounded to 3 decimal places (~100m precision)
- Same route asked twice within 5 minutes = instant, free, zero API call

**Coordinate normalisation** handles all input formats present in the codebase:

| Input Format | Example | How Detected |
|---|---|---|
| "lat,lng" string | `"12.34,56.78"` | String with comma |
| `[lat, lng]` array | `[12.34, 56.78]` | Array, neither value > 90 |
| `[lng, lat]` array | `[180.0, 12.34]` | Array, first value absolute > 90 |
| `{lat, lng}` object | `{lat: 12.34, lng: 56.78}` | Non-array with .lat/.lng props |
| `{latitude, longitude}` object | `{latitude: 12.34, longitude: 56.78}` | Non-array with .latitude/.longitude props |
| `null` / `undefined` | — | Returns null |

### `services/providers/mapplsProvider.js`
The ONLY file that constructs Mappls API URLs or parses Mappls response format.

**Exported functions:**

| Function | Mappls API Endpoint | Purpose |
|---|---|---|
| `distance(lat1, lng1, lat2, lng2, profile)` | `distance_matrix/{profile}/lng,lat;lng,lat` | Road distance + duration |
| `routePolyline(path, profile)` | `route_adv/{profile}/lng,lat;...?geometries=geojson` | Map polyline drawing |
| `staticMapImage(lat, lng, options)` | `still_image?center=lng,lat&...` | Merchant location thumbnail |

**To add a new provider** (e.g. OSRM in future):
1. Create `services/providers/osrmProvider.js` exporting same 3 functions
2. In `MapService.js` line 21, change `this.provider = mappls` to `this.provider = require('./providers/osrmProvider')`
3. Zero other files touched

---

## Files Modified

### `utils/customerAppHelpers.js`
- Removed `const axios = require("axios")`
- Added `const mapService = require("../services/MapService")`
- `getDistanceFromPickupToDelivery()` body replaced with delegation:
  ```js
  // Before: 40 lines of manual URL construction + axios + response parsing
  // After:
  const result = await mapService.getDistance(pickupCoordinates, deliveryCoordinates, profile);
  return result;
  ```
- `getDistanceFromMultipleCoordinates()` body replaced with delegation:
  ```js
  return mapService.getDistanceMulti(coordinates, profile);
  ```
- Both functions **still exported** for backward compatibility but now delegate to MapService

### `utils/createOrderHelpers.js`
- Added `const mapService = require("../services/MapService")`
- Removed `getDistanceFromPickupToDelivery` from customerAppHelpers import
- 3 call sites replaced: `getDistanceFromPickupToDelivery(...)` → `mapService.getDistance(...)`
- Note: still contains `toMapMyIndia()` helper and `normalizeLatLng()` — these are format-only helpers no longer used for API calls

### `controllers/admin/map/mapController.js`
- Removed `const axios = require("axios")`
- Added `const mapService = require("../../../services/MapService")`
- Removed inline `normalizeLatLng()` function (40 lines)
- Replaced raw axios call with `mapService.getRoutePolyline(normalizedPath, "biking")`
- Uses `mapService.normalize()` for coordinate validation

### `controllers/admin/merchant/merchantController.js`
- Added `const mapService = require("../../../services/MapService")`
- **2 instances** of hardcoded API key `9a632cda78b871b3a6eb69bddc470fef` removed
- Replaced with: `mapService.getStaticMapImage(lat, lng, { size: "400x500", zoom: 15 })`
- Removed dead `const buffer = Buffer.from(response.data)` lines (variable name conflict)
- Note: `axios` import kept — still used for CSV download at line 1771

### `controllers/agent/agentController.js`
- Removed `getDistanceFromPickupToDelivery` import from customerAppHelpers
- Added `const mapService = require("../../services/MapService")`
- 1 call site replaced

### `controllers/admin/order/merchantOrderController.js`
- Removed `getDistanceFromPickupToDelivery` from import
- Added `const mapService = require("../../../services/MapService")`
- 1 call site replaced

### `controllers/admin/deliveryManagement/taskController.js`
- Removed `getDistanceFromPickupToDelivery` from import
- Added `const mapService = require("../../../services/MapService")`
- 3 call sites replaced

### `controllers/customer/universalOrderController.js`
- Removed `getDistanceFromPickupToDelivery` from import
- Added `const mapService = require("../../services/MapService")`
- 1 call site replaced (1 more in a comment — not live)

### `controllers/customer/customOrderController.js`
- Removed `getDistanceFromPickupToDelivery` from import
- Added `const mapService = require("../../services/MapService")`
- 2 call sites replaced

### `controllers/customer/pickAndDropController.js`
- Removed `getDistanceFromMultipleCoordinates` from import
- Added `const mapService = require("../../services/MapService")`
- 1 call site replaced (`getDistanceFromMultipleCoordinates` → `mapService.getDistanceMulti`)

### `socket/socket.js`
- Removed `getDistanceFromPickupToDelivery` from import
- Added `const mapService = require("../services/MapService")`
- **8 active call sites + 5 commented call sites** replaced

---

## Files Unchanged (Not Affected)

| File | Reason |
|---|---|
| `index.js` | Still calls `generateMapplsAuthToken()` on startup — dead code but unrelated to the abstraction |
| `controllers/Token/tokenOperation.js` | Generates Mappls OAuth token that is never used by any distance call. The `/get-auth-token` endpoint is still served for **frontend map display** |
| `utils/getGeoLocation.js` | `geoLocation()` is geofence containment (Turf.js), `calculateRoadDistance()` is dead code. Neither routes through Mappls |
| `controllers/admin/order/adminOrderController.js` | 1 commented-out `getDistanceFromMultipleCoordinates` — dead code |
| `controllers/customer/customerController.js` | Uses `geoLocation()` for geofence containment — unrelated |
| `utils/agentAppHelpers.js` | Uses `order.distance` from DB — no API call |
| `utils/ProcessOrderService.js` | Reads `tempOrder.distance` from pre-calculated value — no API call |

---

## Frontend Impact

### Dashboard (`Famto_Dashboard/`)
- Still fetches Mappls auth token via `GET /token/get-auth-token` for **map display** (not distance calculation)
- Uses Mappls SDK (`mappls-web-maps`) for map rendering — this is a client-side map library, independent of backend
- Calls `POST /admin/map/get-polyline` for route line display — **this endpoint still works**, now backed by `mapService.getRoutePolyline()` but returns the same response format

### `famto_order_react/`
- Also fetches Mappls auth token via `GET /token/get-auth-token` for **map display**
- No polyline or distance API calls to backend

### Flutter App (`famto_app/`)
- No Mappls-related API calls found in the Flutter project

### ✅ No frontend changes required
The map display (what the user sees — roads, buildings, pins) stays on Mappls SDK — that's a separate cost and technology. The backend MapService abstraction only changes how distance/route/static image APIs are called. All backend endpoints (`/get-polyline`, `/get-auth-token`, merchant location image generation) return the same response format as before.

---

## Remaining Cleanup Items (Future)

| Item | File | Priority | Effort |
|---|---|---|---|
| Delete dead `calculateRoadDistance()` | `utils/getGeoLocation.js` | Low | 2 min |
| Remove `generateMapplsAuthToken()` startup call | `index.js` + `tokenOperation.js` | Low | 15 min (verify no frontend dependency) |
| Rename `toMapMyIndia()` in `handleDeliveryMode` | `utils/createOrderHelpers.js` | Cosmetic | 5 min |
| Remove bridge exports from customerAppHelpers | `utils/customerAppHelpers.js` | Low | 5 min (after confirming no remaining callers) |
| Add OSRM provider + switch over | New file + one-line change | Cost-saving | 1 day + VPS setup |
| Clean up commented-out Mappls code in socket.js | `socket/socket.js` | Cosmetic | 10 min |
| Remove `generateMapplsAuthToken` seeding in adminSeeder | `DBSeeder/adminSeeder.js` | Low | 5 min |

---

## Verification

All 13 modified files were verified:
- Module loading: no import errors
- All old imports replaced with MapService equivalent
- No remaining `apis.mapmyindia.com` URLs outside `services/providers/mapplsProvider.js`
- No remaining `getDistanceFromPickupToDelivery` calls in any controller or socket
- Normalisation handles all 5 input formats the codebase uses
- Cache key generation is deterministic and correctly rounds coordinates
- Singleton guarantees all importers share the same cache instance