### PR TITLE
fix 50rs cashback

### DIFF
--- a/controllers/agent/agentController.js
+++ b/controllers/agent/agentController.js
@@ -47,6 +47,7 @@ const {
   updateCustomerSubscriptionCount,
   updateAgentDetailsForBatch,
 } = require("../../utils/agentAppHelpers");
+const { creditMilestoneBonus } = require("../../utils/firstOrderBonusHelper");
 const mapService = require("../../services/MapService");
 const { formatDate, formatTime } = require("../../utils/formatters");
 const {
@@ -2399,6 +2400,7 @@ const completeOrderController = async (req, res, next) => {
       orderFound.save(),
       customerFound.save(),
       agentFound.save(),
+      creditMilestoneBonus(orderFound),
     ]);
 
     console.log("✅ Agent after save check...");

--- a/utils/ProcessOrderService.js
+++ b/utils/ProcessOrderService.js
@@ -179,13 +179,6 @@ const processOrderService = async (tempOrder) => {
 
     await session.commitTransaction();
 
-    // Fire-and-forget: credit milestone bonus — non-blocking, never throws
-    setImmediate(() => {
-      creditMilestoneBonus(finalOrder._id).catch(err =>
-        console.error("[BONUS] async credit failed:", err.message)
-      );
-    });
-
     return finalOrder;
   } catch (err) {
     await session.abortTransaction();

--- a/utils/firstOrderBonusHelper.js
+++ b/utils/firstOrderBonusHelper.js
@@ -19,6 +19,8 @@ const resolveOrderObject = async (orderInput) => {
  * Credit 50rs bonus if customer's first qualifying order (>= 300) completed.
  * One-time only — uses three-state enum: unclaimed / claimed / clawed_back.
  * Non-blocking: never throws, never blocks the completion flow.
+ * 
+ * For COD orders, only credits after payment is collected from customer.
  */
 exports.creditMilestoneBonus = async (orderInput) => {
   try {
@@ -27,6 +29,16 @@ exports.creditMilestoneBonus = async (orderInput) => {
 
     const grandTotal = order.billDetail?.grandTotal || 0;
     if (grandTotal < MIN_ORDER_AMOUNT) return;
+
+    // For COD orders, only credit after payment is collected
+    if (order.paymentMode === "Cash-on-delivery") {
+      if (order.paymentCollectedFromCustomer !== "Completed") {
+        console.log(
+          `[BONUS] Skipping bonus for COD order ${order._id} - payment not collected yet`
+        );
+        return;
+      }
+    }
 
     const customer = await Customer.findById(order.customerId);
     if (!customer) return;


### PR DESCRIPTION
# COD Order Bonus Bug Fix - Detailed Report

## 🐛 The Problem

Customers who placed Cash-on-Delivery (COD) orders above ₹300 were receiving a ₹50 first-order bonus immediately upon order creation, even if they cancelled the order before delivery. This created a loophole where customers could:

1. Place a COD order for ₹300+
2. Receive ₹50 instantly in their wallet
3. Cancel the order
4. Keep the ₹50 (despite never completing a qualifying order)

---

## 🔍 Root Cause Analysis

### Issue #1: Premature Bonus Crediting

**Location:** `utils/ProcessOrderService.js` (lines 183-187)

```javascript
// ❌ BEFORE: Bonus credited at order creation
await session.commitTransaction();

setImmediate(() => {
  creditMilestoneBonus(finalOrder._id).catch(err =>
    console.error("[BONUS] async credit failed:", err.message)
  );
});

return finalOrder;
```

**Problem:** The bonus was being credited immediately after order creation using `setImmediate()`, which runs asynchronously right after the order is created. This happened regardless of:
- Payment mode (Online, COD, Famto-cash)
- Order completion status
- Whether payment was actually collected

For COD orders specifically, this meant customers got the bonus before they even paid or received their order.

---

### Issue #2: Missing Payment Verification

**Location:** `utils/firstOrderBonusHelper.js`

```javascript
// ❌ BEFORE: Only checked order total, not payment status
exports.creditMilestoneBonus = async (orderInput) => {
  try {
    const order = await resolveOrderObject(orderInput);
    if (!order || !order.customerId) return;

    const grandTotal = order.billDetail?.grandTotal || 0;
    if (grandTotal < MIN_ORDER_AMOUNT) return;
    
    // No check for COD payment collection!
    
    const customer = await Customer.findById(order.customerId);
    // ... credit bonus
  }
}
```

**Problem:** The helper function only validated:
- Order exists
- Order total >= ₹300

It completely ignored the `paymentCollectedFromCustomer` field, which for COD orders should be `"Completed"` before crediting the bonus.

---

### Issue #3: Missing Bonus in Agent Completion Flow

**Location:** `controllers/agent/agentController.js`

**Problem:** When delivery agents marked orders as complete through their app, the `creditMilestoneBonus` function was never called. This meant legitimate customers who completed orders via the agent app never received their ₹50 bonus.

The admin completion flow (`controllers/admin/order/adminOrderController.js` line 3340) correctly called the bonus function, but the agent flow didn't.

---

## ✅ The Solution

### Fix #1: Remove Premature Bonus Credit

**File:** `utils/ProcessOrderService.js`

```javascript
// ✅ AFTER: No bonus credit at order creation
await session.commitTransaction();

return finalOrder;
```

**Why:** Order creation should only create the order. Bonus credit is now deferred until order completion.

---

### Fix #2: Add COD Payment Verification

**File:** `utils/firstOrderBonusHelper.js`

```javascript
// ✅ AFTER: Verify COD payment before crediting bonus
exports.creditMilestoneBonus = async (orderInput) => {
  try {
    const order = await resolveOrderObject(orderInput);
    if (!order || !order.customerId) return;

    const grandTotal = order.billDetail?.grandTotal || 0;
    if (grandTotal < MIN_ORDER_AMOUNT) return;

    // ✅ NEW: For COD orders, verify payment was collected
    if (order.paymentMode === "Cash-on-delivery") {
      if (order.paymentCollectedFromCustomer !== "Completed") {
        console.log(
          `[BONUS] Skipping bonus for COD order ${order._id} - payment not collected yet`
        );
        return;
      }
    }

    const customer = await Customer.findById(order.customerId);
    // ... proceed with bonus credit
  }
}
```

**Why:** This ensures COD orders only trigger the bonus after the agent confirms payment collection from the customer.

---

### Fix #3: Add Bonus to Agent Completion Flow

**File:** `controllers/agent/agentController.js`

```javascript
// ✅ Import the bonus function
const { creditMilestoneBonus } = require("../../utils/firstOrderBonusHelper");

// ✅ Call bonus credit during order completion
await Promise.all([
  orderFound.save(),
  customerFound.save(),
  agentFound.save(),
  creditMilestoneBonus(orderFound), // ✅ NEW: Credit bonus here
]);
```

**Why:** Agents can complete orders independently, so the bonus must be credited in this flow too.

---

## 🎯 How It Works Now

The bonus system now follows this corrected flow:

### For Online Payment Orders:
1. Customer places order → Order created (NO bonus yet)
2. Payment processed → Order status = "Pending"
3. Agent completes delivery → Order status = "Completed"
4. **Bonus credited** ✅ (because order completed + paid)

### For Cash-on-Delivery Orders:
1. Customer places order → Order created (NO bonus yet)
2. Agent delivers order → Order status = "Completed"
3. Agent confirms cash received → `paymentCollectedFromCustomer` = "Completed"
4. **Bonus credited** ✅ (because order completed + payment collected)

### For Cancelled Orders:
1. Customer places order → Order created (NO bonus yet)
2. Customer/Admin cancels → Order status = "Cancelled"
3. **No bonus credited** ✅ (order never reached completion)

---

## 📊 Technical Summary

| Aspect | Before | After |
|--------|--------|-------|
| **Bonus Timing** | Order creation | Order completion |
| **COD Verification** | None | Checks `paymentCollectedFromCustomer` |
| **Agent Flow** | Missing | Implemented |
| **Cancellation Safety** | Clawback required | No bonus to clawback |

---

## 🔒 Security Improvements

1. **Eliminates the exploit window** - No brief period where customers have unearned bonus
2. **Proper payment verification** - COD orders require confirmed payment collection
3. **Complete coverage** - Both admin and agent completion flows now credit bonus
4. **Consistent behavior** - All payment modes follow the same "complete before credit" principle

---

## 🧪 Testing Scenarios

To verify the fix works:

1. **COD Order Completion:** Place COD order ₹300+, complete it, confirm cash collected → Bonus credited ✅
2. **COD Order Cancellation:** Place COD order ₹300+, cancel before completion → No bonus ✅
3. **Online Payment:** Place online order ₹300+, complete it → Bonus credited ✅
4. **Agent Completion:** Complete order through agent app → Bonus credited ✅
5. **Below Threshold:** Place order < ₹300, complete it → No bonus ✅

---

## 📝 Files Modified

1. **utils/ProcessOrderService.js** - Removed premature bonus credit
2. **utils/firstOrderBonusHelper.js** - Added COD payment verification
3. **controllers/agent/agentController.js** - Added bonus credit to completion flow